### PR TITLE
fix mavlink codegen enum methods

### DIFF
--- a/pkg/dialects/all/enum_mav_cmd.go
+++ b/pkg/dialects/all/enum_mav_cmd.go
@@ -3,7 +3,8 @@
 package all
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data. NaN and INT32_MAX may be used in float/integer params (respectively) to indicate optional/default values (e.g. to use the component's current yaw or latitude rather than a specific value). See https://mavlink.io/en/guide/xml_schema.html#MAV_CMD for information about the structure of the MAV_CMD entries
@@ -698,27 +699,38 @@ var labels_MAV_CMD = map[MAV_CMD]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_CMD[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_CMD {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_CMD = map[string]MAV_CMD{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_CMD[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_CMD
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_CMD {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD) String() string {
-	if l, ok := labels_MAV_CMD[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_accelcal_vehicle_pos.go
+++ b/pkg/dialects/ardupilotmega/enum_accelcal_vehicle_pos.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type ACCELCAL_VEHICLE_POS uint32
@@ -32,27 +33,38 @@ var labels_ACCELCAL_VEHICLE_POS = map[ACCELCAL_VEHICLE_POS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ACCELCAL_VEHICLE_POS) MarshalText() ([]byte, error) {
-	if l, ok := labels_ACCELCAL_VEHICLE_POS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_ACCELCAL_VEHICLE_POS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_ACCELCAL_VEHICLE_POS = map[string]ACCELCAL_VEHICLE_POS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ACCELCAL_VEHICLE_POS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_ACCELCAL_VEHICLE_POS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask ACCELCAL_VEHICLE_POS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_ACCELCAL_VEHICLE_POS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ACCELCAL_VEHICLE_POS) String() string {
-	if l, ok := labels_ACCELCAL_VEHICLE_POS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_camera_feedback_flags.go
+++ b/pkg/dialects/ardupilotmega/enum_camera_feedback_flags.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type CAMERA_FEEDBACK_FLAGS uint32
@@ -31,27 +32,38 @@ var labels_CAMERA_FEEDBACK_FLAGS = map[CAMERA_FEEDBACK_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAMERA_FEEDBACK_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_CAMERA_FEEDBACK_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_CAMERA_FEEDBACK_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_CAMERA_FEEDBACK_FLAGS = map[string]CAMERA_FEEDBACK_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CAMERA_FEEDBACK_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_CAMERA_FEEDBACK_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask CAMERA_FEEDBACK_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_CAMERA_FEEDBACK_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CAMERA_FEEDBACK_FLAGS) String() string {
-	if l, ok := labels_CAMERA_FEEDBACK_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_camera_status_types.go
+++ b/pkg/dialects/ardupilotmega/enum_camera_status_types.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type CAMERA_STATUS_TYPES uint32
@@ -37,27 +38,38 @@ var labels_CAMERA_STATUS_TYPES = map[CAMERA_STATUS_TYPES]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAMERA_STATUS_TYPES) MarshalText() ([]byte, error) {
-	if l, ok := labels_CAMERA_STATUS_TYPES[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_CAMERA_STATUS_TYPES {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_CAMERA_STATUS_TYPES = map[string]CAMERA_STATUS_TYPES{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CAMERA_STATUS_TYPES) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_CAMERA_STATUS_TYPES[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask CAMERA_STATUS_TYPES
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_CAMERA_STATUS_TYPES {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CAMERA_STATUS_TYPES) String() string {
-	if l, ok := labels_CAMERA_STATUS_TYPES[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_copter_mode.go
+++ b/pkg/dialects/ardupilotmega/enum_copter_mode.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // A mapping of copter flight modes for custom_mode field of heartbeat.
@@ -67,27 +68,38 @@ var labels_COPTER_MODE = map[COPTER_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e COPTER_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_COPTER_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_COPTER_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_COPTER_MODE = map[string]COPTER_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *COPTER_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_COPTER_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask COPTER_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_COPTER_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e COPTER_MODE) String() string {
-	if l, ok := labels_COPTER_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_device_op_bustype.go
+++ b/pkg/dialects/ardupilotmega/enum_device_op_bustype.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Bus types for device operations.
@@ -23,27 +24,38 @@ var labels_DEVICE_OP_BUSTYPE = map[DEVICE_OP_BUSTYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e DEVICE_OP_BUSTYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_DEVICE_OP_BUSTYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_DEVICE_OP_BUSTYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_DEVICE_OP_BUSTYPE = map[string]DEVICE_OP_BUSTYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *DEVICE_OP_BUSTYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_DEVICE_OP_BUSTYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask DEVICE_OP_BUSTYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_DEVICE_OP_BUSTYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e DEVICE_OP_BUSTYPE) String() string {
-	if l, ok := labels_DEVICE_OP_BUSTYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_ekf_status_flags.go
+++ b/pkg/dialects/ardupilotmega/enum_ekf_status_flags.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Flags in EKF_STATUS message.
@@ -50,27 +51,38 @@ var labels_EKF_STATUS_FLAGS = map[EKF_STATUS_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e EKF_STATUS_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_EKF_STATUS_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_EKF_STATUS_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_EKF_STATUS_FLAGS = map[string]EKF_STATUS_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *EKF_STATUS_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_EKF_STATUS_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask EKF_STATUS_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_EKF_STATUS_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e EKF_STATUS_FLAGS) String() string {
-	if l, ok := labels_EKF_STATUS_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gimbal_axis_calibration_required.go
+++ b/pkg/dialects/ardupilotmega/enum_gimbal_axis_calibration_required.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GIMBAL_AXIS_CALIBRATION_REQUIRED uint32
@@ -25,27 +26,38 @@ var labels_GIMBAL_AXIS_CALIBRATION_REQUIRED = map[GIMBAL_AXIS_CALIBRATION_REQUIR
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GIMBAL_AXIS_CALIBRATION_REQUIRED) MarshalText() ([]byte, error) {
-	if l, ok := labels_GIMBAL_AXIS_CALIBRATION_REQUIRED[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GIMBAL_AXIS_CALIBRATION_REQUIRED {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GIMBAL_AXIS_CALIBRATION_REQUIRED = map[string]GIMBAL_AXIS_CALIBRATION_REQUIRED{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GIMBAL_AXIS_CALIBRATION_REQUIRED) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GIMBAL_AXIS_CALIBRATION_REQUIRED[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GIMBAL_AXIS_CALIBRATION_REQUIRED
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GIMBAL_AXIS_CALIBRATION_REQUIRED {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GIMBAL_AXIS_CALIBRATION_REQUIRED) String() string {
-	if l, ok := labels_GIMBAL_AXIS_CALIBRATION_REQUIRED[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gimbal_axis_calibration_status.go
+++ b/pkg/dialects/ardupilotmega/enum_gimbal_axis_calibration_status.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GIMBAL_AXIS_CALIBRATION_STATUS uint32
@@ -25,27 +26,38 @@ var labels_GIMBAL_AXIS_CALIBRATION_STATUS = map[GIMBAL_AXIS_CALIBRATION_STATUS]s
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GIMBAL_AXIS_CALIBRATION_STATUS) MarshalText() ([]byte, error) {
-	if l, ok := labels_GIMBAL_AXIS_CALIBRATION_STATUS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GIMBAL_AXIS_CALIBRATION_STATUS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GIMBAL_AXIS_CALIBRATION_STATUS = map[string]GIMBAL_AXIS_CALIBRATION_STATUS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GIMBAL_AXIS_CALIBRATION_STATUS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GIMBAL_AXIS_CALIBRATION_STATUS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GIMBAL_AXIS_CALIBRATION_STATUS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GIMBAL_AXIS_CALIBRATION_STATUS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GIMBAL_AXIS_CALIBRATION_STATUS) String() string {
-	if l, ok := labels_GIMBAL_AXIS_CALIBRATION_STATUS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_burst_rate.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_burst_rate.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_BURST_RATE uint32
@@ -43,27 +44,38 @@ var labels_GOPRO_BURST_RATE = map[GOPRO_BURST_RATE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_BURST_RATE) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_BURST_RATE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_BURST_RATE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_BURST_RATE = map[string]GOPRO_BURST_RATE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_BURST_RATE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_BURST_RATE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_BURST_RATE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_BURST_RATE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_BURST_RATE) String() string {
-	if l, ok := labels_GOPRO_BURST_RATE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_capture_mode.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_capture_mode.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_CAPTURE_MODE uint32
@@ -40,27 +41,38 @@ var labels_GOPRO_CAPTURE_MODE = map[GOPRO_CAPTURE_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_CAPTURE_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_CAPTURE_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_CAPTURE_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_CAPTURE_MODE = map[string]GOPRO_CAPTURE_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_CAPTURE_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_CAPTURE_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_CAPTURE_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_CAPTURE_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_CAPTURE_MODE) String() string {
-	if l, ok := labels_GOPRO_CAPTURE_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_charging.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_charging.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_CHARGING uint32
@@ -22,27 +23,38 @@ var labels_GOPRO_CHARGING = map[GOPRO_CHARGING]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_CHARGING) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_CHARGING[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_CHARGING {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_CHARGING = map[string]GOPRO_CHARGING{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_CHARGING) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_CHARGING[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_CHARGING
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_CHARGING {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_CHARGING) String() string {
-	if l, ok := labels_GOPRO_CHARGING[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_field_of_view.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_field_of_view.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_FIELD_OF_VIEW uint32
@@ -25,27 +26,38 @@ var labels_GOPRO_FIELD_OF_VIEW = map[GOPRO_FIELD_OF_VIEW]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_FIELD_OF_VIEW) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_FIELD_OF_VIEW[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_FIELD_OF_VIEW {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_FIELD_OF_VIEW = map[string]GOPRO_FIELD_OF_VIEW{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_FIELD_OF_VIEW) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_FIELD_OF_VIEW[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_FIELD_OF_VIEW
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_FIELD_OF_VIEW {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_FIELD_OF_VIEW) String() string {
-	if l, ok := labels_GOPRO_FIELD_OF_VIEW[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_frame_rate.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_frame_rate.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_FRAME_RATE uint32
@@ -58,27 +59,38 @@ var labels_GOPRO_FRAME_RATE = map[GOPRO_FRAME_RATE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_FRAME_RATE) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_FRAME_RATE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_FRAME_RATE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_FRAME_RATE = map[string]GOPRO_FRAME_RATE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_FRAME_RATE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_FRAME_RATE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_FRAME_RATE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_FRAME_RATE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_FRAME_RATE) String() string {
-	if l, ok := labels_GOPRO_FRAME_RATE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_heartbeat_flags.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_heartbeat_flags.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_HEARTBEAT_FLAGS uint32
@@ -19,27 +20,38 @@ var labels_GOPRO_HEARTBEAT_FLAGS = map[GOPRO_HEARTBEAT_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_HEARTBEAT_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_HEARTBEAT_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_HEARTBEAT_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_HEARTBEAT_FLAGS = map[string]GOPRO_HEARTBEAT_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_HEARTBEAT_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_HEARTBEAT_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_HEARTBEAT_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_HEARTBEAT_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_HEARTBEAT_FLAGS) String() string {
-	if l, ok := labels_GOPRO_HEARTBEAT_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_heartbeat_status.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_heartbeat_status.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_HEARTBEAT_STATUS uint32
@@ -28,27 +29,38 @@ var labels_GOPRO_HEARTBEAT_STATUS = map[GOPRO_HEARTBEAT_STATUS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_HEARTBEAT_STATUS) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_HEARTBEAT_STATUS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_HEARTBEAT_STATUS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_HEARTBEAT_STATUS = map[string]GOPRO_HEARTBEAT_STATUS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_HEARTBEAT_STATUS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_HEARTBEAT_STATUS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_HEARTBEAT_STATUS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_HEARTBEAT_STATUS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_HEARTBEAT_STATUS) String() string {
-	if l, ok := labels_GOPRO_HEARTBEAT_STATUS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_model.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_model.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_MODEL uint32
@@ -31,27 +32,38 @@ var labels_GOPRO_MODEL = map[GOPRO_MODEL]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_MODEL) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_MODEL[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_MODEL {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_MODEL = map[string]GOPRO_MODEL{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_MODEL) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_MODEL[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_MODEL
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_MODEL {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_MODEL) String() string {
-	if l, ok := labels_GOPRO_MODEL[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_photo_resolution.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_photo_resolution.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_PHOTO_RESOLUTION uint32
@@ -31,27 +32,38 @@ var labels_GOPRO_PHOTO_RESOLUTION = map[GOPRO_PHOTO_RESOLUTION]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_PHOTO_RESOLUTION) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_PHOTO_RESOLUTION[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_PHOTO_RESOLUTION {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_PHOTO_RESOLUTION = map[string]GOPRO_PHOTO_RESOLUTION{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_PHOTO_RESOLUTION) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_PHOTO_RESOLUTION[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_PHOTO_RESOLUTION
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_PHOTO_RESOLUTION {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_PHOTO_RESOLUTION) String() string {
-	if l, ok := labels_GOPRO_PHOTO_RESOLUTION[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_protune_colour.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_protune_colour.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_PROTUNE_COLOUR uint32
@@ -22,27 +23,38 @@ var labels_GOPRO_PROTUNE_COLOUR = map[GOPRO_PROTUNE_COLOUR]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_PROTUNE_COLOUR) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_PROTUNE_COLOUR[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_PROTUNE_COLOUR {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_PROTUNE_COLOUR = map[string]GOPRO_PROTUNE_COLOUR{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_PROTUNE_COLOUR) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_PROTUNE_COLOUR[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_PROTUNE_COLOUR
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_PROTUNE_COLOUR {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_PROTUNE_COLOUR) String() string {
-	if l, ok := labels_GOPRO_PROTUNE_COLOUR[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_protune_exposure.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_protune_exposure.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_PROTUNE_EXPOSURE uint32
@@ -79,27 +80,38 @@ var labels_GOPRO_PROTUNE_EXPOSURE = map[GOPRO_PROTUNE_EXPOSURE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_PROTUNE_EXPOSURE) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_PROTUNE_EXPOSURE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_PROTUNE_EXPOSURE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_PROTUNE_EXPOSURE = map[string]GOPRO_PROTUNE_EXPOSURE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_PROTUNE_EXPOSURE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_PROTUNE_EXPOSURE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_PROTUNE_EXPOSURE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_PROTUNE_EXPOSURE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_PROTUNE_EXPOSURE) String() string {
-	if l, ok := labels_GOPRO_PROTUNE_EXPOSURE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_protune_gain.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_protune_gain.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_PROTUNE_GAIN uint32
@@ -31,27 +32,38 @@ var labels_GOPRO_PROTUNE_GAIN = map[GOPRO_PROTUNE_GAIN]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_PROTUNE_GAIN) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_PROTUNE_GAIN[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_PROTUNE_GAIN {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_PROTUNE_GAIN = map[string]GOPRO_PROTUNE_GAIN{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_PROTUNE_GAIN) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_PROTUNE_GAIN[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_PROTUNE_GAIN
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_PROTUNE_GAIN {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_PROTUNE_GAIN) String() string {
-	if l, ok := labels_GOPRO_PROTUNE_GAIN[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_protune_sharpness.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_protune_sharpness.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_PROTUNE_SHARPNESS uint32
@@ -25,27 +26,38 @@ var labels_GOPRO_PROTUNE_SHARPNESS = map[GOPRO_PROTUNE_SHARPNESS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_PROTUNE_SHARPNESS) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_PROTUNE_SHARPNESS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_PROTUNE_SHARPNESS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_PROTUNE_SHARPNESS = map[string]GOPRO_PROTUNE_SHARPNESS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_PROTUNE_SHARPNESS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_PROTUNE_SHARPNESS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_PROTUNE_SHARPNESS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_PROTUNE_SHARPNESS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_PROTUNE_SHARPNESS) String() string {
-	if l, ok := labels_GOPRO_PROTUNE_SHARPNESS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_protune_white_balance.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_protune_white_balance.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_PROTUNE_WHITE_BALANCE uint32
@@ -31,27 +32,38 @@ var labels_GOPRO_PROTUNE_WHITE_BALANCE = map[GOPRO_PROTUNE_WHITE_BALANCE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_PROTUNE_WHITE_BALANCE) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_PROTUNE_WHITE_BALANCE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_PROTUNE_WHITE_BALANCE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_PROTUNE_WHITE_BALANCE = map[string]GOPRO_PROTUNE_WHITE_BALANCE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_PROTUNE_WHITE_BALANCE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_PROTUNE_WHITE_BALANCE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_PROTUNE_WHITE_BALANCE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_PROTUNE_WHITE_BALANCE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_PROTUNE_WHITE_BALANCE) String() string {
-	if l, ok := labels_GOPRO_PROTUNE_WHITE_BALANCE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_request_status.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_request_status.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_REQUEST_STATUS uint32
@@ -22,27 +23,38 @@ var labels_GOPRO_REQUEST_STATUS = map[GOPRO_REQUEST_STATUS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_REQUEST_STATUS) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_REQUEST_STATUS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_REQUEST_STATUS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_REQUEST_STATUS = map[string]GOPRO_REQUEST_STATUS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_REQUEST_STATUS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_REQUEST_STATUS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_REQUEST_STATUS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_REQUEST_STATUS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_REQUEST_STATUS) String() string {
-	if l, ok := labels_GOPRO_REQUEST_STATUS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_resolution.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_resolution.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_RESOLUTION uint32
@@ -58,27 +59,38 @@ var labels_GOPRO_RESOLUTION = map[GOPRO_RESOLUTION]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_RESOLUTION) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_RESOLUTION[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_RESOLUTION {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_RESOLUTION = map[string]GOPRO_RESOLUTION{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_RESOLUTION) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_RESOLUTION[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_RESOLUTION
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_RESOLUTION {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_RESOLUTION) String() string {
-	if l, ok := labels_GOPRO_RESOLUTION[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_video_settings_flags.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_video_settings_flags.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GOPRO_VIDEO_SETTINGS_FLAGS uint32
@@ -19,27 +20,38 @@ var labels_GOPRO_VIDEO_SETTINGS_FLAGS = map[GOPRO_VIDEO_SETTINGS_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_VIDEO_SETTINGS_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_GOPRO_VIDEO_SETTINGS_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GOPRO_VIDEO_SETTINGS_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GOPRO_VIDEO_SETTINGS_FLAGS = map[string]GOPRO_VIDEO_SETTINGS_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_VIDEO_SETTINGS_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GOPRO_VIDEO_SETTINGS_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GOPRO_VIDEO_SETTINGS_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GOPRO_VIDEO_SETTINGS_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_VIDEO_SETTINGS_FLAGS) String() string {
-	if l, ok := labels_GOPRO_VIDEO_SETTINGS_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_heading_type.go
+++ b/pkg/dialects/ardupilotmega/enum_heading_type.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type HEADING_TYPE uint32
@@ -20,27 +21,38 @@ var labels_HEADING_TYPE = map[HEADING_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e HEADING_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_HEADING_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_HEADING_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_HEADING_TYPE = map[string]HEADING_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *HEADING_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_HEADING_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask HEADING_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_HEADING_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e HEADING_TYPE) String() string {
-	if l, ok := labels_HEADING_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_limit_module.go
+++ b/pkg/dialects/ardupilotmega/enum_limit_module.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type LIMIT_MODULE uint32
@@ -25,27 +26,38 @@ var labels_LIMIT_MODULE = map[LIMIT_MODULE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e LIMIT_MODULE) MarshalText() ([]byte, error) {
-	if l, ok := labels_LIMIT_MODULE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_LIMIT_MODULE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_LIMIT_MODULE = map[string]LIMIT_MODULE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *LIMIT_MODULE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_LIMIT_MODULE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask LIMIT_MODULE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_LIMIT_MODULE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e LIMIT_MODULE) String() string {
-	if l, ok := labels_LIMIT_MODULE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_limits_state.go
+++ b/pkg/dialects/ardupilotmega/enum_limits_state.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type LIMITS_STATE uint32
@@ -34,27 +35,38 @@ var labels_LIMITS_STATE = map[LIMITS_STATE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e LIMITS_STATE) MarshalText() ([]byte, error) {
-	if l, ok := labels_LIMITS_STATE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_LIMITS_STATE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_LIMITS_STATE = map[string]LIMITS_STATE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *LIMITS_STATE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_LIMITS_STATE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask LIMITS_STATE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_LIMITS_STATE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e LIMITS_STATE) String() string {
-	if l, ok := labels_LIMITS_STATE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_mav_cmd.go
+++ b/pkg/dialects/ardupilotmega/enum_mav_cmd.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data. NaN and INT32_MAX may be used in float/integer params (respectively) to indicate optional/default values (e.g. to use the component's current yaw or latitude rather than a specific value). See https://mavlink.io/en/guide/xml_schema.html#MAV_CMD for information about the structure of the MAV_CMD entries
@@ -619,27 +620,38 @@ var labels_MAV_CMD = map[MAV_CMD]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_CMD[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_CMD {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_CMD = map[string]MAV_CMD{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_CMD[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_CMD
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_CMD {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD) String() string {
-	if l, ok := labels_MAV_CMD[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_mav_cmd_do_aux_function_switch_level.go
+++ b/pkg/dialects/ardupilotmega/enum_mav_cmd_do_aux_function_switch_level.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL uint32
@@ -25,27 +26,38 @@ var labels_MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL = map[MAV_CMD_DO_AUX_FUNCTION_SW
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL = map[string]MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL) String() string {
-	if l, ok := labels_MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_mav_mode_gimbal.go
+++ b/pkg/dialects/ardupilotmega/enum_mav_mode_gimbal.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_MODE_GIMBAL uint32
@@ -37,27 +38,38 @@ var labels_MAV_MODE_GIMBAL = map[MAV_MODE_GIMBAL]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MODE_GIMBAL) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_MODE_GIMBAL[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_MODE_GIMBAL {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_MODE_GIMBAL = map[string]MAV_MODE_GIMBAL{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_MODE_GIMBAL) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_MODE_GIMBAL[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_MODE_GIMBAL
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_MODE_GIMBAL {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_MODE_GIMBAL) String() string {
-	if l, ok := labels_MAV_MODE_GIMBAL[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_mav_remote_log_data_block_commands.go
+++ b/pkg/dialects/ardupilotmega/enum_mav_remote_log_data_block_commands.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Special ACK block numbers control activation of dataflash log streaming.
@@ -23,27 +24,38 @@ var labels_MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS = map[MAV_REMOTE_LOG_DATA_BLOCK_CO
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS = map[string]MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS) String() string {
-	if l, ok := labels_MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_mav_remote_log_data_block_statuses.go
+++ b/pkg/dialects/ardupilotmega/enum_mav_remote_log_data_block_statuses.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Possible remote log data block statuses.
@@ -23,27 +24,38 @@ var labels_MAV_REMOTE_LOG_DATA_BLOCK_STATUSES = map[MAV_REMOTE_LOG_DATA_BLOCK_ST
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_REMOTE_LOG_DATA_BLOCK_STATUSES) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_REMOTE_LOG_DATA_BLOCK_STATUSES[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_REMOTE_LOG_DATA_BLOCK_STATUSES {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_REMOTE_LOG_DATA_BLOCK_STATUSES = map[string]MAV_REMOTE_LOG_DATA_BLOCK_STATUSES{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_REMOTE_LOG_DATA_BLOCK_STATUSES) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_REMOTE_LOG_DATA_BLOCK_STATUSES[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_REMOTE_LOG_DATA_BLOCK_STATUSES
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_REMOTE_LOG_DATA_BLOCK_STATUSES {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_REMOTE_LOG_DATA_BLOCK_STATUSES) String() string {
-	if l, ok := labels_MAV_REMOTE_LOG_DATA_BLOCK_STATUSES[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_osd_param_config_type.go
+++ b/pkg/dialects/ardupilotmega/enum_osd_param_config_type.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // The type of parameter for the OSD parameter editor.
@@ -35,27 +36,38 @@ var labels_OSD_PARAM_CONFIG_TYPE = map[OSD_PARAM_CONFIG_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e OSD_PARAM_CONFIG_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_OSD_PARAM_CONFIG_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_OSD_PARAM_CONFIG_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_OSD_PARAM_CONFIG_TYPE = map[string]OSD_PARAM_CONFIG_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *OSD_PARAM_CONFIG_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_OSD_PARAM_CONFIG_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask OSD_PARAM_CONFIG_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_OSD_PARAM_CONFIG_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e OSD_PARAM_CONFIG_TYPE) String() string {
-	if l, ok := labels_OSD_PARAM_CONFIG_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_rally_flags.go
+++ b/pkg/dialects/ardupilotmega/enum_rally_flags.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Flags in RALLY_POINT message.
@@ -23,27 +24,38 @@ var labels_RALLY_FLAGS = map[RALLY_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e RALLY_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_RALLY_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_RALLY_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_RALLY_FLAGS = map[string]RALLY_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *RALLY_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_RALLY_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask RALLY_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_RALLY_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e RALLY_FLAGS) String() string {
-	if l, ok := labels_RALLY_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_rover_mode.go
+++ b/pkg/dialects/ardupilotmega/enum_rover_mode.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // A mapping of rover flight modes for custom_mode field of heartbeat.
@@ -41,27 +42,38 @@ var labels_ROVER_MODE = map[ROVER_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ROVER_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_ROVER_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_ROVER_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_ROVER_MODE = map[string]ROVER_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ROVER_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_ROVER_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask ROVER_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_ROVER_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ROVER_MODE) String() string {
-	if l, ok := labels_ROVER_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_scripting_cmd.go
+++ b/pkg/dialects/ardupilotmega/enum_scripting_cmd.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type SCRIPTING_CMD uint32
@@ -28,27 +29,38 @@ var labels_SCRIPTING_CMD = map[SCRIPTING_CMD]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e SCRIPTING_CMD) MarshalText() ([]byte, error) {
-	if l, ok := labels_SCRIPTING_CMD[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_SCRIPTING_CMD {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_SCRIPTING_CMD = map[string]SCRIPTING_CMD{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *SCRIPTING_CMD) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_SCRIPTING_CMD[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask SCRIPTING_CMD
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_SCRIPTING_CMD {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e SCRIPTING_CMD) String() string {
-	if l, ok := labels_SCRIPTING_CMD[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_speed_type.go
+++ b/pkg/dialects/ardupilotmega/enum_speed_type.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type SPEED_TYPE uint32
@@ -20,27 +21,38 @@ var labels_SPEED_TYPE = map[SPEED_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e SPEED_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_SPEED_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_SPEED_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_SPEED_TYPE = map[string]SPEED_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *SPEED_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_SPEED_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask SPEED_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_SPEED_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e SPEED_TYPE) String() string {
-	if l, ok := labels_SPEED_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_sub_mode.go
+++ b/pkg/dialects/ardupilotmega/enum_sub_mode.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // A mapping of sub flight modes for custom_mode field of heartbeat.
@@ -35,27 +36,38 @@ var labels_SUB_MODE = map[SUB_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e SUB_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_SUB_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_SUB_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_SUB_MODE = map[string]SUB_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *SUB_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_SUB_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask SUB_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_SUB_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e SUB_MODE) String() string {
-	if l, ok := labels_SUB_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ardupilotmega/enum_tracker_mode.go
+++ b/pkg/dialects/ardupilotmega/enum_tracker_mode.go
@@ -3,7 +3,8 @@
 package ardupilotmega
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // A mapping of antenna tracker flight modes for custom_mode field of heartbeat.
@@ -29,27 +30,38 @@ var labels_TRACKER_MODE = map[TRACKER_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e TRACKER_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_TRACKER_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_TRACKER_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_TRACKER_MODE = map[string]TRACKER_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *TRACKER_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_TRACKER_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask TRACKER_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_TRACKER_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e TRACKER_MODE) String() string {
-	if l, ok := labels_TRACKER_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/asluav/enum_gsm_link_type.go
+++ b/pkg/dialects/asluav/enum_gsm_link_type.go
@@ -3,7 +3,8 @@
 package asluav
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GSM_LINK_TYPE uint32
@@ -31,27 +32,38 @@ var labels_GSM_LINK_TYPE = map[GSM_LINK_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GSM_LINK_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_GSM_LINK_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GSM_LINK_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GSM_LINK_TYPE = map[string]GSM_LINK_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GSM_LINK_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GSM_LINK_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GSM_LINK_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GSM_LINK_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GSM_LINK_TYPE) String() string {
-	if l, ok := labels_GSM_LINK_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/asluav/enum_gsm_modem_type.go
+++ b/pkg/dialects/asluav/enum_gsm_modem_type.go
@@ -3,7 +3,8 @@
 package asluav
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GSM_MODEM_TYPE uint32
@@ -22,27 +23,38 @@ var labels_GSM_MODEM_TYPE = map[GSM_MODEM_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GSM_MODEM_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_GSM_MODEM_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GSM_MODEM_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GSM_MODEM_TYPE = map[string]GSM_MODEM_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GSM_MODEM_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GSM_MODEM_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GSM_MODEM_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GSM_MODEM_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GSM_MODEM_TYPE) String() string {
-	if l, ok := labels_GSM_MODEM_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/asluav/enum_mav_cmd.go
+++ b/pkg/dialects/asluav/enum_mav_cmd.go
@@ -3,7 +3,8 @@
 package asluav
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data. NaN and INT32_MAX may be used in float/integer params (respectively) to indicate optional/default values (e.g. to use the component's current yaw or latitude rather than a specific value). See https://mavlink.io/en/guide/xml_schema.html#MAV_CMD for information about the structure of the MAV_CMD entries
@@ -531,27 +532,38 @@ var labels_MAV_CMD = map[MAV_CMD]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_CMD[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_CMD {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_CMD = map[string]MAV_CMD{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_CMD[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_CMD
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_CMD {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD) String() string {
-	if l, ok := labels_MAV_CMD[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/avssuas/enum_avss_horsefly_operation_mode.go
+++ b/pkg/dialects/avssuas/enum_avss_horsefly_operation_mode.go
@@ -3,7 +3,8 @@
 package avssuas
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type AVSS_HORSEFLY_OPERATION_MODE uint32
@@ -31,27 +32,38 @@ var labels_AVSS_HORSEFLY_OPERATION_MODE = map[AVSS_HORSEFLY_OPERATION_MODE]strin
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e AVSS_HORSEFLY_OPERATION_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_AVSS_HORSEFLY_OPERATION_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_AVSS_HORSEFLY_OPERATION_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_AVSS_HORSEFLY_OPERATION_MODE = map[string]AVSS_HORSEFLY_OPERATION_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *AVSS_HORSEFLY_OPERATION_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_AVSS_HORSEFLY_OPERATION_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask AVSS_HORSEFLY_OPERATION_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_AVSS_HORSEFLY_OPERATION_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e AVSS_HORSEFLY_OPERATION_MODE) String() string {
-	if l, ok := labels_AVSS_HORSEFLY_OPERATION_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/avssuas/enum_avss_m300_operation_mode.go
+++ b/pkg/dialects/avssuas/enum_avss_m300_operation_mode.go
@@ -3,7 +3,8 @@
 package avssuas
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type AVSS_M300_OPERATION_MODE uint32
@@ -58,27 +59,38 @@ var labels_AVSS_M300_OPERATION_MODE = map[AVSS_M300_OPERATION_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e AVSS_M300_OPERATION_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_AVSS_M300_OPERATION_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_AVSS_M300_OPERATION_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_AVSS_M300_OPERATION_MODE = map[string]AVSS_M300_OPERATION_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *AVSS_M300_OPERATION_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_AVSS_M300_OPERATION_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask AVSS_M300_OPERATION_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_AVSS_M300_OPERATION_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e AVSS_M300_OPERATION_MODE) String() string {
-	if l, ok := labels_AVSS_M300_OPERATION_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/avssuas/enum_mav_avss_command_failure_reason.go
+++ b/pkg/dialects/avssuas/enum_mav_avss_command_failure_reason.go
@@ -3,7 +3,8 @@
 package avssuas
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_AVSS_COMMAND_FAILURE_REASON uint32
@@ -25,27 +26,38 @@ var labels_MAV_AVSS_COMMAND_FAILURE_REASON = map[MAV_AVSS_COMMAND_FAILURE_REASON
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_AVSS_COMMAND_FAILURE_REASON) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_AVSS_COMMAND_FAILURE_REASON[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_AVSS_COMMAND_FAILURE_REASON {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_AVSS_COMMAND_FAILURE_REASON = map[string]MAV_AVSS_COMMAND_FAILURE_REASON{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_AVSS_COMMAND_FAILURE_REASON) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_AVSS_COMMAND_FAILURE_REASON[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_AVSS_COMMAND_FAILURE_REASON
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_AVSS_COMMAND_FAILURE_REASON {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_AVSS_COMMAND_FAILURE_REASON) String() string {
-	if l, ok := labels_MAV_AVSS_COMMAND_FAILURE_REASON[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_adsb_altitude_type.go
+++ b/pkg/dialects/common/enum_adsb_altitude_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Enumeration of the ADSB altimeter types
@@ -23,27 +24,38 @@ var labels_ADSB_ALTITUDE_TYPE = map[ADSB_ALTITUDE_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ADSB_ALTITUDE_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_ADSB_ALTITUDE_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_ADSB_ALTITUDE_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_ADSB_ALTITUDE_TYPE = map[string]ADSB_ALTITUDE_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ADSB_ALTITUDE_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_ADSB_ALTITUDE_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask ADSB_ALTITUDE_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_ADSB_ALTITUDE_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ADSB_ALTITUDE_TYPE) String() string {
-	if l, ok := labels_ADSB_ALTITUDE_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_adsb_emitter_type.go
+++ b/pkg/dialects/common/enum_adsb_emitter_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // ADSB classification for the type of vehicle emitting the transponder signal
@@ -57,27 +58,38 @@ var labels_ADSB_EMITTER_TYPE = map[ADSB_EMITTER_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ADSB_EMITTER_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_ADSB_EMITTER_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_ADSB_EMITTER_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_ADSB_EMITTER_TYPE = map[string]ADSB_EMITTER_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ADSB_EMITTER_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_ADSB_EMITTER_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask ADSB_EMITTER_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_ADSB_EMITTER_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ADSB_EMITTER_TYPE) String() string {
-	if l, ok := labels_ADSB_EMITTER_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_ais_type.go
+++ b/pkg/dialects/common/enum_ais_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Type of AIS vessel, enum duplicated from AIS standard, https://gpsd.gitlab.io/gpsd/AIVDM.html
@@ -225,27 +226,38 @@ var labels_AIS_TYPE = map[AIS_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e AIS_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_AIS_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_AIS_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_AIS_TYPE = map[string]AIS_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *AIS_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_AIS_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask AIS_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_AIS_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e AIS_TYPE) String() string {
-	if l, ok := labels_AIS_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_attitude_target_typemask.go
+++ b/pkg/dialects/common/enum_attitude_target_typemask.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Bitmap to indicate which dimensions should be ignored by the vehicle: a value of 0b00000000 indicates that none of the setpoint dimensions should be ignored.
@@ -35,27 +36,38 @@ var labels_ATTITUDE_TARGET_TYPEMASK = map[ATTITUDE_TARGET_TYPEMASK]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ATTITUDE_TARGET_TYPEMASK) MarshalText() ([]byte, error) {
-	if l, ok := labels_ATTITUDE_TARGET_TYPEMASK[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_ATTITUDE_TARGET_TYPEMASK {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_ATTITUDE_TARGET_TYPEMASK = map[string]ATTITUDE_TARGET_TYPEMASK{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ATTITUDE_TARGET_TYPEMASK) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_ATTITUDE_TARGET_TYPEMASK[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask ATTITUDE_TARGET_TYPEMASK
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_ATTITUDE_TARGET_TYPEMASK {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ATTITUDE_TARGET_TYPEMASK) String() string {
-	if l, ok := labels_ATTITUDE_TARGET_TYPEMASK[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_camera_cap_flags.go
+++ b/pkg/dialects/common/enum_camera_cap_flags.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Camera capability flags (Bitmap)
@@ -53,27 +54,38 @@ var labels_CAMERA_CAP_FLAGS = map[CAMERA_CAP_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAMERA_CAP_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_CAMERA_CAP_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_CAMERA_CAP_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_CAMERA_CAP_FLAGS = map[string]CAMERA_CAP_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CAMERA_CAP_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_CAMERA_CAP_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask CAMERA_CAP_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_CAMERA_CAP_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CAMERA_CAP_FLAGS) String() string {
-	if l, ok := labels_CAMERA_CAP_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_camera_mode.go
+++ b/pkg/dialects/common/enum_camera_mode.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Camera Modes.
@@ -26,27 +27,38 @@ var labels_CAMERA_MODE = map[CAMERA_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAMERA_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_CAMERA_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_CAMERA_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_CAMERA_MODE = map[string]CAMERA_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CAMERA_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_CAMERA_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask CAMERA_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_CAMERA_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CAMERA_MODE) String() string {
-	if l, ok := labels_CAMERA_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_camera_tracking_mode.go
+++ b/pkg/dialects/common/enum_camera_tracking_mode.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Camera tracking modes
@@ -26,27 +27,38 @@ var labels_CAMERA_TRACKING_MODE = map[CAMERA_TRACKING_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAMERA_TRACKING_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_CAMERA_TRACKING_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_CAMERA_TRACKING_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_CAMERA_TRACKING_MODE = map[string]CAMERA_TRACKING_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CAMERA_TRACKING_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_CAMERA_TRACKING_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask CAMERA_TRACKING_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_CAMERA_TRACKING_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CAMERA_TRACKING_MODE) String() string {
-	if l, ok := labels_CAMERA_TRACKING_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_camera_tracking_status_flags.go
+++ b/pkg/dialects/common/enum_camera_tracking_status_flags.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Camera tracking status flags
@@ -26,27 +27,38 @@ var labels_CAMERA_TRACKING_STATUS_FLAGS = map[CAMERA_TRACKING_STATUS_FLAGS]strin
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAMERA_TRACKING_STATUS_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_CAMERA_TRACKING_STATUS_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_CAMERA_TRACKING_STATUS_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_CAMERA_TRACKING_STATUS_FLAGS = map[string]CAMERA_TRACKING_STATUS_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CAMERA_TRACKING_STATUS_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_CAMERA_TRACKING_STATUS_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask CAMERA_TRACKING_STATUS_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_CAMERA_TRACKING_STATUS_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CAMERA_TRACKING_STATUS_FLAGS) String() string {
-	if l, ok := labels_CAMERA_TRACKING_STATUS_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_camera_zoom_type.go
+++ b/pkg/dialects/common/enum_camera_zoom_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Zoom types for MAV_CMD_SET_CAMERA_ZOOM
@@ -29,27 +30,38 @@ var labels_CAMERA_ZOOM_TYPE = map[CAMERA_ZOOM_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAMERA_ZOOM_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_CAMERA_ZOOM_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_CAMERA_ZOOM_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_CAMERA_ZOOM_TYPE = map[string]CAMERA_ZOOM_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CAMERA_ZOOM_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_CAMERA_ZOOM_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask CAMERA_ZOOM_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_CAMERA_ZOOM_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CAMERA_ZOOM_TYPE) String() string {
-	if l, ok := labels_CAMERA_ZOOM_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_cellular_config_response.go
+++ b/pkg/dialects/common/enum_cellular_config_response.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Possible responses from a CELLULAR_CONFIG message.
@@ -32,27 +33,38 @@ var labels_CELLULAR_CONFIG_RESPONSE = map[CELLULAR_CONFIG_RESPONSE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CELLULAR_CONFIG_RESPONSE) MarshalText() ([]byte, error) {
-	if l, ok := labels_CELLULAR_CONFIG_RESPONSE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_CELLULAR_CONFIG_RESPONSE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_CELLULAR_CONFIG_RESPONSE = map[string]CELLULAR_CONFIG_RESPONSE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CELLULAR_CONFIG_RESPONSE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_CELLULAR_CONFIG_RESPONSE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask CELLULAR_CONFIG_RESPONSE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_CELLULAR_CONFIG_RESPONSE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CELLULAR_CONFIG_RESPONSE) String() string {
-	if l, ok := labels_CELLULAR_CONFIG_RESPONSE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_cellular_network_failed_reason.go
+++ b/pkg/dialects/common/enum_cellular_network_failed_reason.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // These flags are used to diagnose the failure state of CELLULAR_STATUS
@@ -29,27 +30,38 @@ var labels_CELLULAR_NETWORK_FAILED_REASON = map[CELLULAR_NETWORK_FAILED_REASON]s
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CELLULAR_NETWORK_FAILED_REASON) MarshalText() ([]byte, error) {
-	if l, ok := labels_CELLULAR_NETWORK_FAILED_REASON[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_CELLULAR_NETWORK_FAILED_REASON {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_CELLULAR_NETWORK_FAILED_REASON = map[string]CELLULAR_NETWORK_FAILED_REASON{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CELLULAR_NETWORK_FAILED_REASON) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_CELLULAR_NETWORK_FAILED_REASON[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask CELLULAR_NETWORK_FAILED_REASON
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_CELLULAR_NETWORK_FAILED_REASON {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CELLULAR_NETWORK_FAILED_REASON) String() string {
-	if l, ok := labels_CELLULAR_NETWORK_FAILED_REASON[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_cellular_network_radio_type.go
+++ b/pkg/dialects/common/enum_cellular_network_radio_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Cellular network radio type
@@ -27,27 +28,38 @@ var labels_CELLULAR_NETWORK_RADIO_TYPE = map[CELLULAR_NETWORK_RADIO_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CELLULAR_NETWORK_RADIO_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_CELLULAR_NETWORK_RADIO_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_CELLULAR_NETWORK_RADIO_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_CELLULAR_NETWORK_RADIO_TYPE = map[string]CELLULAR_NETWORK_RADIO_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CELLULAR_NETWORK_RADIO_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_CELLULAR_NETWORK_RADIO_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask CELLULAR_NETWORK_RADIO_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_CELLULAR_NETWORK_RADIO_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CELLULAR_NETWORK_RADIO_TYPE) String() string {
-	if l, ok := labels_CELLULAR_NETWORK_RADIO_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_comp_metadata_type.go
+++ b/pkg/dialects/common/enum_comp_metadata_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Supported component metadata types. These are used in the "general" metadata file returned by COMPONENT_METADATA to provide information about supported metadata types. The types are not used directly in MAVLink messages.
@@ -35,27 +36,38 @@ var labels_COMP_METADATA_TYPE = map[COMP_METADATA_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e COMP_METADATA_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_COMP_METADATA_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_COMP_METADATA_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_COMP_METADATA_TYPE = map[string]COMP_METADATA_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *COMP_METADATA_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_COMP_METADATA_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask COMP_METADATA_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_COMP_METADATA_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e COMP_METADATA_TYPE) String() string {
-	if l, ok := labels_COMP_METADATA_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_esc_failure_flags.go
+++ b/pkg/dialects/common/enum_esc_failure_flags.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Flags to report ESC failures.
@@ -41,27 +42,38 @@ var labels_ESC_FAILURE_FLAGS = map[ESC_FAILURE_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ESC_FAILURE_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_ESC_FAILURE_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_ESC_FAILURE_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_ESC_FAILURE_FLAGS = map[string]ESC_FAILURE_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ESC_FAILURE_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_ESC_FAILURE_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask ESC_FAILURE_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_ESC_FAILURE_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ESC_FAILURE_FLAGS) String() string {
-	if l, ok := labels_ESC_FAILURE_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_estimator_status_flags.go
+++ b/pkg/dialects/common/enum_estimator_status_flags.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Flags in ESTIMATOR_STATUS message
@@ -53,27 +54,38 @@ var labels_ESTIMATOR_STATUS_FLAGS = map[ESTIMATOR_STATUS_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ESTIMATOR_STATUS_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_ESTIMATOR_STATUS_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_ESTIMATOR_STATUS_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_ESTIMATOR_STATUS_FLAGS = map[string]ESTIMATOR_STATUS_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ESTIMATOR_STATUS_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_ESTIMATOR_STATUS_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask ESTIMATOR_STATUS_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_ESTIMATOR_STATUS_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ESTIMATOR_STATUS_FLAGS) String() string {
-	if l, ok := labels_ESTIMATOR_STATUS_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_failure_type.go
+++ b/pkg/dialects/common/enum_failure_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // List of possible failure type to inject.
@@ -41,27 +42,38 @@ var labels_FAILURE_TYPE = map[FAILURE_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e FAILURE_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_FAILURE_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_FAILURE_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_FAILURE_TYPE = map[string]FAILURE_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *FAILURE_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_FAILURE_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask FAILURE_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_FAILURE_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e FAILURE_TYPE) String() string {
-	if l, ok := labels_FAILURE_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_fence_action.go
+++ b/pkg/dialects/common/enum_fence_action.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Actions following geofence breach.
@@ -41,27 +42,38 @@ var labels_FENCE_ACTION = map[FENCE_ACTION]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e FENCE_ACTION) MarshalText() ([]byte, error) {
-	if l, ok := labels_FENCE_ACTION[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_FENCE_ACTION {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_FENCE_ACTION = map[string]FENCE_ACTION{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *FENCE_ACTION) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_FENCE_ACTION[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask FENCE_ACTION
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_FENCE_ACTION {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e FENCE_ACTION) String() string {
-	if l, ok := labels_FENCE_ACTION[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_fence_breach.go
+++ b/pkg/dialects/common/enum_fence_breach.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type FENCE_BREACH uint32
@@ -28,27 +29,38 @@ var labels_FENCE_BREACH = map[FENCE_BREACH]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e FENCE_BREACH) MarshalText() ([]byte, error) {
-	if l, ok := labels_FENCE_BREACH[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_FENCE_BREACH {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_FENCE_BREACH = map[string]FENCE_BREACH{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *FENCE_BREACH) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_FENCE_BREACH[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask FENCE_BREACH
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_FENCE_BREACH {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e FENCE_BREACH) String() string {
-	if l, ok := labels_FENCE_BREACH[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_firmware_version_type.go
+++ b/pkg/dialects/common/enum_firmware_version_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // These values define the type of firmware release.  These values indicate the first version or release of this type.  For example the first alpha release would be 64, the second would be 65.
@@ -32,27 +33,38 @@ var labels_FIRMWARE_VERSION_TYPE = map[FIRMWARE_VERSION_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e FIRMWARE_VERSION_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_FIRMWARE_VERSION_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_FIRMWARE_VERSION_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_FIRMWARE_VERSION_TYPE = map[string]FIRMWARE_VERSION_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *FIRMWARE_VERSION_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_FIRMWARE_VERSION_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask FIRMWARE_VERSION_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_FIRMWARE_VERSION_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e FIRMWARE_VERSION_TYPE) String() string {
-	if l, ok := labels_FIRMWARE_VERSION_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_gimbal_device_cap_flags.go
+++ b/pkg/dialects/common/enum_gimbal_device_cap_flags.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Gimbal device (low level) capability flags (bitmap).
@@ -59,27 +60,38 @@ var labels_GIMBAL_DEVICE_CAP_FLAGS = map[GIMBAL_DEVICE_CAP_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GIMBAL_DEVICE_CAP_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_GIMBAL_DEVICE_CAP_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GIMBAL_DEVICE_CAP_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GIMBAL_DEVICE_CAP_FLAGS = map[string]GIMBAL_DEVICE_CAP_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GIMBAL_DEVICE_CAP_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GIMBAL_DEVICE_CAP_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GIMBAL_DEVICE_CAP_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GIMBAL_DEVICE_CAP_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GIMBAL_DEVICE_CAP_FLAGS) String() string {
-	if l, ok := labels_GIMBAL_DEVICE_CAP_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_gimbal_device_error_flags.go
+++ b/pkg/dialects/common/enum_gimbal_device_error_flags.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Gimbal device (low level) error flags (bitmap, 0 means no error)
@@ -47,27 +48,38 @@ var labels_GIMBAL_DEVICE_ERROR_FLAGS = map[GIMBAL_DEVICE_ERROR_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GIMBAL_DEVICE_ERROR_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_GIMBAL_DEVICE_ERROR_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GIMBAL_DEVICE_ERROR_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GIMBAL_DEVICE_ERROR_FLAGS = map[string]GIMBAL_DEVICE_ERROR_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GIMBAL_DEVICE_ERROR_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GIMBAL_DEVICE_ERROR_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GIMBAL_DEVICE_ERROR_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GIMBAL_DEVICE_ERROR_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GIMBAL_DEVICE_ERROR_FLAGS) String() string {
-	if l, ok := labels_GIMBAL_DEVICE_ERROR_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_gimbal_device_flags.go
+++ b/pkg/dialects/common/enum_gimbal_device_flags.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Flags for gimbal device (lower level) operation.
@@ -47,27 +48,38 @@ var labels_GIMBAL_DEVICE_FLAGS = map[GIMBAL_DEVICE_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GIMBAL_DEVICE_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_GIMBAL_DEVICE_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GIMBAL_DEVICE_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GIMBAL_DEVICE_FLAGS = map[string]GIMBAL_DEVICE_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GIMBAL_DEVICE_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GIMBAL_DEVICE_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GIMBAL_DEVICE_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GIMBAL_DEVICE_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GIMBAL_DEVICE_FLAGS) String() string {
-	if l, ok := labels_GIMBAL_DEVICE_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_gimbal_manager_cap_flags.go
+++ b/pkg/dialects/common/enum_gimbal_manager_cap_flags.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Gimbal manager high level capability flags (bitmap). The first 16 bits are identical to the GIMBAL_DEVICE_CAP_FLAGS. However, the gimbal manager does not need to copy the flags from the gimbal but can also enhance the capabilities and thus add flags.
@@ -65,27 +66,38 @@ var labels_GIMBAL_MANAGER_CAP_FLAGS = map[GIMBAL_MANAGER_CAP_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GIMBAL_MANAGER_CAP_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_GIMBAL_MANAGER_CAP_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GIMBAL_MANAGER_CAP_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GIMBAL_MANAGER_CAP_FLAGS = map[string]GIMBAL_MANAGER_CAP_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GIMBAL_MANAGER_CAP_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GIMBAL_MANAGER_CAP_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GIMBAL_MANAGER_CAP_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GIMBAL_MANAGER_CAP_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GIMBAL_MANAGER_CAP_FLAGS) String() string {
-	if l, ok := labels_GIMBAL_MANAGER_CAP_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_gimbal_manager_flags.go
+++ b/pkg/dialects/common/enum_gimbal_manager_flags.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Flags for high level gimbal manager operation The first 16 bits are identical to the GIMBAL_DEVICE_FLAGS.
@@ -47,27 +48,38 @@ var labels_GIMBAL_MANAGER_FLAGS = map[GIMBAL_MANAGER_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GIMBAL_MANAGER_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_GIMBAL_MANAGER_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GIMBAL_MANAGER_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GIMBAL_MANAGER_FLAGS = map[string]GIMBAL_MANAGER_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GIMBAL_MANAGER_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GIMBAL_MANAGER_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GIMBAL_MANAGER_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GIMBAL_MANAGER_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GIMBAL_MANAGER_FLAGS) String() string {
-	if l, ok := labels_GIMBAL_MANAGER_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_gps_input_ignore_flags.go
+++ b/pkg/dialects/common/enum_gps_input_ignore_flags.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type GPS_INPUT_IGNORE_FLAGS uint32
@@ -40,27 +41,38 @@ var labels_GPS_INPUT_IGNORE_FLAGS = map[GPS_INPUT_IGNORE_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GPS_INPUT_IGNORE_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_GPS_INPUT_IGNORE_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GPS_INPUT_IGNORE_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GPS_INPUT_IGNORE_FLAGS = map[string]GPS_INPUT_IGNORE_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GPS_INPUT_IGNORE_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GPS_INPUT_IGNORE_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GPS_INPUT_IGNORE_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GPS_INPUT_IGNORE_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GPS_INPUT_IGNORE_FLAGS) String() string {
-	if l, ok := labels_GPS_INPUT_IGNORE_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_gripper_actions.go
+++ b/pkg/dialects/common/enum_gripper_actions.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Gripper actions.
@@ -23,27 +24,38 @@ var labels_GRIPPER_ACTIONS = map[GRIPPER_ACTIONS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GRIPPER_ACTIONS) MarshalText() ([]byte, error) {
-	if l, ok := labels_GRIPPER_ACTIONS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_GRIPPER_ACTIONS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_GRIPPER_ACTIONS = map[string]GRIPPER_ACTIONS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GRIPPER_ACTIONS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_GRIPPER_ACTIONS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask GRIPPER_ACTIONS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_GRIPPER_ACTIONS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GRIPPER_ACTIONS) String() string {
-	if l, ok := labels_GRIPPER_ACTIONS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_highres_imu_updated_flags.go
+++ b/pkg/dialects/common/enum_highres_imu_updated_flags.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Flags in the HIGHRES_IMU message indicate which fields have updated since the last message
@@ -62,27 +63,38 @@ var labels_HIGHRES_IMU_UPDATED_FLAGS = map[HIGHRES_IMU_UPDATED_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e HIGHRES_IMU_UPDATED_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_HIGHRES_IMU_UPDATED_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_HIGHRES_IMU_UPDATED_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_HIGHRES_IMU_UPDATED_FLAGS = map[string]HIGHRES_IMU_UPDATED_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *HIGHRES_IMU_UPDATED_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_HIGHRES_IMU_UPDATED_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask HIGHRES_IMU_UPDATED_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_HIGHRES_IMU_UPDATED_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e HIGHRES_IMU_UPDATED_FLAGS) String() string {
-	if l, ok := labels_HIGHRES_IMU_UPDATED_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_hil_sensor_updated_flags.go
+++ b/pkg/dialects/common/enum_hil_sensor_updated_flags.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Flags in the HIL_SENSOR message indicate which fields have updated since the last message
@@ -62,27 +63,38 @@ var labels_HIL_SENSOR_UPDATED_FLAGS = map[HIL_SENSOR_UPDATED_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e HIL_SENSOR_UPDATED_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_HIL_SENSOR_UPDATED_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_HIL_SENSOR_UPDATED_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_HIL_SENSOR_UPDATED_FLAGS = map[string]HIL_SENSOR_UPDATED_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *HIL_SENSOR_UPDATED_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_HIL_SENSOR_UPDATED_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask HIL_SENSOR_UPDATED_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_HIL_SENSOR_UPDATED_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e HIL_SENSOR_UPDATED_FLAGS) String() string {
-	if l, ok := labels_HIL_SENSOR_UPDATED_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_hl_failure_flag.go
+++ b/pkg/dialects/common/enum_hl_failure_flag.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Flags to report failure cases over the high latency telemtry.
@@ -59,27 +60,38 @@ var labels_HL_FAILURE_FLAG = map[HL_FAILURE_FLAG]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e HL_FAILURE_FLAG) MarshalText() ([]byte, error) {
-	if l, ok := labels_HL_FAILURE_FLAG[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_HL_FAILURE_FLAG {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_HL_FAILURE_FLAG = map[string]HL_FAILURE_FLAG{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *HL_FAILURE_FLAG) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_HL_FAILURE_FLAG[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask HL_FAILURE_FLAG
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_HL_FAILURE_FLAG {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e HL_FAILURE_FLAG) String() string {
-	if l, ok := labels_HL_FAILURE_FLAG[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_landing_target_type.go
+++ b/pkg/dialects/common/enum_landing_target_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Type of landing target
@@ -29,27 +30,38 @@ var labels_LANDING_TARGET_TYPE = map[LANDING_TARGET_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e LANDING_TARGET_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_LANDING_TARGET_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_LANDING_TARGET_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_LANDING_TARGET_TYPE = map[string]LANDING_TARGET_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *LANDING_TARGET_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_LANDING_TARGET_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask LANDING_TARGET_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_LANDING_TARGET_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e LANDING_TARGET_TYPE) String() string {
-	if l, ok := labels_LANDING_TARGET_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mag_cal_status.go
+++ b/pkg/dialects/common/enum_mag_cal_status.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAG_CAL_STATUS uint32
@@ -32,27 +33,38 @@ var labels_MAG_CAL_STATUS = map[MAG_CAL_STATUS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAG_CAL_STATUS) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAG_CAL_STATUS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAG_CAL_STATUS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAG_CAL_STATUS = map[string]MAG_CAL_STATUS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAG_CAL_STATUS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAG_CAL_STATUS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAG_CAL_STATUS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAG_CAL_STATUS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAG_CAL_STATUS) String() string {
-	if l, ok := labels_MAG_CAL_STATUS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_arm_auth_denied_reason.go
+++ b/pkg/dialects/common/enum_mav_arm_auth_denied_reason.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ARM_AUTH_DENIED_REASON uint32
@@ -34,27 +35,38 @@ var labels_MAV_ARM_AUTH_DENIED_REASON = map[MAV_ARM_AUTH_DENIED_REASON]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ARM_AUTH_DENIED_REASON) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ARM_AUTH_DENIED_REASON[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ARM_AUTH_DENIED_REASON {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ARM_AUTH_DENIED_REASON = map[string]MAV_ARM_AUTH_DENIED_REASON{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ARM_AUTH_DENIED_REASON) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ARM_AUTH_DENIED_REASON[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ARM_AUTH_DENIED_REASON
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ARM_AUTH_DENIED_REASON {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ARM_AUTH_DENIED_REASON) String() string {
-	if l, ok := labels_MAV_ARM_AUTH_DENIED_REASON[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_battery_charge_state.go
+++ b/pkg/dialects/common/enum_mav_battery_charge_state.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Enumeration for battery charge states.
@@ -41,27 +42,38 @@ var labels_MAV_BATTERY_CHARGE_STATE = map[MAV_BATTERY_CHARGE_STATE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_BATTERY_CHARGE_STATE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_BATTERY_CHARGE_STATE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_BATTERY_CHARGE_STATE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_BATTERY_CHARGE_STATE = map[string]MAV_BATTERY_CHARGE_STATE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_BATTERY_CHARGE_STATE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_BATTERY_CHARGE_STATE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_BATTERY_CHARGE_STATE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_BATTERY_CHARGE_STATE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_BATTERY_CHARGE_STATE) String() string {
-	if l, ok := labels_MAV_BATTERY_CHARGE_STATE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_battery_fault.go
+++ b/pkg/dialects/common/enum_mav_battery_fault.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Smart battery supply status/fault flags (bitmask) for health indication. The battery must also report either MAV_BATTERY_CHARGE_STATE_FAILED or MAV_BATTERY_CHARGE_STATE_UNHEALTHY if any of these are set.
@@ -44,27 +45,38 @@ var labels_MAV_BATTERY_FAULT = map[MAV_BATTERY_FAULT]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_BATTERY_FAULT) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_BATTERY_FAULT[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_BATTERY_FAULT {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_BATTERY_FAULT = map[string]MAV_BATTERY_FAULT{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_BATTERY_FAULT) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_BATTERY_FAULT[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_BATTERY_FAULT
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_BATTERY_FAULT {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_BATTERY_FAULT) String() string {
-	if l, ok := labels_MAV_BATTERY_FAULT[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_battery_function.go
+++ b/pkg/dialects/common/enum_mav_battery_function.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Enumeration of battery functions
@@ -32,27 +33,38 @@ var labels_MAV_BATTERY_FUNCTION = map[MAV_BATTERY_FUNCTION]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_BATTERY_FUNCTION) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_BATTERY_FUNCTION[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_BATTERY_FUNCTION {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_BATTERY_FUNCTION = map[string]MAV_BATTERY_FUNCTION{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_BATTERY_FUNCTION) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_BATTERY_FUNCTION[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_BATTERY_FUNCTION
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_BATTERY_FUNCTION {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_BATTERY_FUNCTION) String() string {
-	if l, ok := labels_MAV_BATTERY_FUNCTION[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_battery_mode.go
+++ b/pkg/dialects/common/enum_mav_battery_mode.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Battery mode. Note, the normal operation mode (i.e. when flying) should be reported as MAV_BATTERY_MODE_UNKNOWN to allow message trimming in normal flight.
@@ -26,27 +27,38 @@ var labels_MAV_BATTERY_MODE = map[MAV_BATTERY_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_BATTERY_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_BATTERY_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_BATTERY_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_BATTERY_MODE = map[string]MAV_BATTERY_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_BATTERY_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_BATTERY_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_BATTERY_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_BATTERY_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_BATTERY_MODE) String() string {
-	if l, ok := labels_MAV_BATTERY_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_battery_type.go
+++ b/pkg/dialects/common/enum_mav_battery_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Enumeration of battery types
@@ -32,27 +33,38 @@ var labels_MAV_BATTERY_TYPE = map[MAV_BATTERY_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_BATTERY_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_BATTERY_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_BATTERY_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_BATTERY_TYPE = map[string]MAV_BATTERY_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_BATTERY_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_BATTERY_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_BATTERY_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_BATTERY_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_BATTERY_TYPE) String() string {
-	if l, ok := labels_MAV_BATTERY_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_cmd.go
+++ b/pkg/dialects/common/enum_mav_cmd.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data. NaN and INT32_MAX may be used in float/integer params (respectively) to indicate optional/default values (e.g. to use the component's current yaw or latitude rather than a specific value). See https://mavlink.io/en/guide/xml_schema.html#MAV_CMD for information about the structure of the MAV_CMD entries
@@ -525,27 +526,38 @@ var labels_MAV_CMD = map[MAV_CMD]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_CMD[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_CMD {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_CMD = map[string]MAV_CMD{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_CMD[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_CMD
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_CMD {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD) String() string {
-	if l, ok := labels_MAV_CMD[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_cmd_ack.go
+++ b/pkg/dialects/common/enum_mav_cmd_ack.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // ACK / NACK / ERROR values as a result of MAV_CMDs and for mission item transmission.
@@ -44,27 +45,38 @@ var labels_MAV_CMD_ACK = map[MAV_CMD_ACK]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD_ACK) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_CMD_ACK[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_CMD_ACK {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_CMD_ACK = map[string]MAV_CMD_ACK{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD_ACK) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_CMD_ACK[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_CMD_ACK
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_CMD_ACK {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD_ACK) String() string {
-	if l, ok := labels_MAV_CMD_ACK[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_collision_action.go
+++ b/pkg/dialects/common/enum_mav_collision_action.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Possible actions an aircraft can take to avoid a collision.
@@ -38,27 +39,38 @@ var labels_MAV_COLLISION_ACTION = map[MAV_COLLISION_ACTION]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_COLLISION_ACTION) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_COLLISION_ACTION[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_COLLISION_ACTION {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_COLLISION_ACTION = map[string]MAV_COLLISION_ACTION{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_COLLISION_ACTION) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_COLLISION_ACTION[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_COLLISION_ACTION
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_COLLISION_ACTION {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_COLLISION_ACTION) String() string {
-	if l, ok := labels_MAV_COLLISION_ACTION[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_collision_src.go
+++ b/pkg/dialects/common/enum_mav_collision_src.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Source of information about this collision.
@@ -23,27 +24,38 @@ var labels_MAV_COLLISION_SRC = map[MAV_COLLISION_SRC]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_COLLISION_SRC) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_COLLISION_SRC[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_COLLISION_SRC {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_COLLISION_SRC = map[string]MAV_COLLISION_SRC{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_COLLISION_SRC) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_COLLISION_SRC[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_COLLISION_SRC
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_COLLISION_SRC {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_COLLISION_SRC) String() string {
-	if l, ok := labels_MAV_COLLISION_SRC[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_collision_threat_level.go
+++ b/pkg/dialects/common/enum_mav_collision_threat_level.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Aircraft-rated danger from this threat.
@@ -26,27 +27,38 @@ var labels_MAV_COLLISION_THREAT_LEVEL = map[MAV_COLLISION_THREAT_LEVEL]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_COLLISION_THREAT_LEVEL) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_COLLISION_THREAT_LEVEL[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_COLLISION_THREAT_LEVEL {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_COLLISION_THREAT_LEVEL = map[string]MAV_COLLISION_THREAT_LEVEL{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_COLLISION_THREAT_LEVEL) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_COLLISION_THREAT_LEVEL[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_COLLISION_THREAT_LEVEL
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_COLLISION_THREAT_LEVEL {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_COLLISION_THREAT_LEVEL) String() string {
-	if l, ok := labels_MAV_COLLISION_THREAT_LEVEL[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_data_stream.go
+++ b/pkg/dialects/common/enum_mav_data_stream.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // A data stream is not a fixed set of messages, but rather a
@@ -46,27 +47,38 @@ var labels_MAV_DATA_STREAM = map[MAV_DATA_STREAM]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_DATA_STREAM) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_DATA_STREAM[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_DATA_STREAM {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_DATA_STREAM = map[string]MAV_DATA_STREAM{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_DATA_STREAM) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_DATA_STREAM[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_DATA_STREAM
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_DATA_STREAM {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_DATA_STREAM) String() string {
-	if l, ok := labels_MAV_DATA_STREAM[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_distance_sensor.go
+++ b/pkg/dialects/common/enum_mav_distance_sensor.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Enumeration of distance sensor types
@@ -32,27 +33,38 @@ var labels_MAV_DISTANCE_SENSOR = map[MAV_DISTANCE_SENSOR]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_DISTANCE_SENSOR) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_DISTANCE_SENSOR[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_DISTANCE_SENSOR {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_DISTANCE_SENSOR = map[string]MAV_DISTANCE_SENSOR{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_DISTANCE_SENSOR) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_DISTANCE_SENSOR[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_DISTANCE_SENSOR
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_DISTANCE_SENSOR {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_DISTANCE_SENSOR) String() string {
-	if l, ok := labels_MAV_DISTANCE_SENSOR[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_do_reposition_flags.go
+++ b/pkg/dialects/common/enum_mav_do_reposition_flags.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Bitmap of options for the MAV_CMD_DO_REPOSITION
@@ -20,27 +21,38 @@ var labels_MAV_DO_REPOSITION_FLAGS = map[MAV_DO_REPOSITION_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_DO_REPOSITION_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_DO_REPOSITION_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_DO_REPOSITION_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_DO_REPOSITION_FLAGS = map[string]MAV_DO_REPOSITION_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_DO_REPOSITION_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_DO_REPOSITION_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_DO_REPOSITION_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_DO_REPOSITION_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_DO_REPOSITION_FLAGS) String() string {
-	if l, ok := labels_MAV_DO_REPOSITION_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_estimator_type.go
+++ b/pkg/dialects/common/enum_mav_estimator_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Enumeration of estimator types
@@ -44,27 +45,38 @@ var labels_MAV_ESTIMATOR_TYPE = map[MAV_ESTIMATOR_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ESTIMATOR_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ESTIMATOR_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ESTIMATOR_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ESTIMATOR_TYPE = map[string]MAV_ESTIMATOR_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ESTIMATOR_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ESTIMATOR_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ESTIMATOR_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ESTIMATOR_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ESTIMATOR_TYPE) String() string {
-	if l, ok := labels_MAV_ESTIMATOR_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_event_current_sequence_flags.go
+++ b/pkg/dialects/common/enum_mav_event_current_sequence_flags.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Flags for CURRENT_EVENT_SEQUENCE.
@@ -20,27 +21,38 @@ var labels_MAV_EVENT_CURRENT_SEQUENCE_FLAGS = map[MAV_EVENT_CURRENT_SEQUENCE_FLA
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_EVENT_CURRENT_SEQUENCE_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_EVENT_CURRENT_SEQUENCE_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_EVENT_CURRENT_SEQUENCE_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_EVENT_CURRENT_SEQUENCE_FLAGS = map[string]MAV_EVENT_CURRENT_SEQUENCE_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_EVENT_CURRENT_SEQUENCE_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_EVENT_CURRENT_SEQUENCE_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_EVENT_CURRENT_SEQUENCE_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_EVENT_CURRENT_SEQUENCE_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_EVENT_CURRENT_SEQUENCE_FLAGS) String() string {
-	if l, ok := labels_MAV_EVENT_CURRENT_SEQUENCE_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_event_error_reason.go
+++ b/pkg/dialects/common/enum_mav_event_error_reason.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Reason for an event error response.
@@ -20,27 +21,38 @@ var labels_MAV_EVENT_ERROR_REASON = map[MAV_EVENT_ERROR_REASON]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_EVENT_ERROR_REASON) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_EVENT_ERROR_REASON[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_EVENT_ERROR_REASON {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_EVENT_ERROR_REASON = map[string]MAV_EVENT_ERROR_REASON{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_EVENT_ERROR_REASON) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_EVENT_ERROR_REASON[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_EVENT_ERROR_REASON
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_EVENT_ERROR_REASON {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_EVENT_ERROR_REASON) String() string {
-	if l, ok := labels_MAV_EVENT_ERROR_REASON[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_frame.go
+++ b/pkg/dialects/common/enum_mav_frame.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Coordinate frames used by MAVLink. Not all frames are supported by all commands, messages, or vehicles.
@@ -96,27 +97,38 @@ var labels_MAV_FRAME = map[MAV_FRAME]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_FRAME) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_FRAME[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_FRAME {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_FRAME = map[string]MAV_FRAME{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_FRAME) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_FRAME[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_FRAME
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_FRAME {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_FRAME) String() string {
-	if l, ok := labels_MAV_FRAME[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_ftp_opcode.go
+++ b/pkg/dialects/common/enum_mav_ftp_opcode.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // MAV FTP opcodes: https://mavlink.io/en/services/ftp.html
@@ -71,27 +72,38 @@ var labels_MAV_FTP_OPCODE = map[MAV_FTP_OPCODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_FTP_OPCODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_FTP_OPCODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_FTP_OPCODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_FTP_OPCODE = map[string]MAV_FTP_OPCODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_FTP_OPCODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_FTP_OPCODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_FTP_OPCODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_FTP_OPCODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_FTP_OPCODE) String() string {
-	if l, ok := labels_MAV_FTP_OPCODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_generator_status_flag.go
+++ b/pkg/dialects/common/enum_mav_generator_status_flag.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Flags to report status/failure cases for a power generator (used in GENERATOR_STATUS). Note that FAULTS are conditions that cause the generator to fail. Warnings are conditions that require attention before the next use (they indicate the system is not operating properly).
@@ -86,27 +87,38 @@ var labels_MAV_GENERATOR_STATUS_FLAG = map[MAV_GENERATOR_STATUS_FLAG]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_GENERATOR_STATUS_FLAG) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_GENERATOR_STATUS_FLAG[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_GENERATOR_STATUS_FLAG {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_GENERATOR_STATUS_FLAG = map[string]MAV_GENERATOR_STATUS_FLAG{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_GENERATOR_STATUS_FLAG) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_GENERATOR_STATUS_FLAG[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_GENERATOR_STATUS_FLAG
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_GENERATOR_STATUS_FLAG {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_GENERATOR_STATUS_FLAG) String() string {
-	if l, ok := labels_MAV_GENERATOR_STATUS_FLAG[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_goto.go
+++ b/pkg/dialects/common/enum_mav_goto.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Actions that may be specified in MAV_CMD_OVERRIDE_GOTO to override mission execution.
@@ -29,27 +30,38 @@ var labels_MAV_GOTO = map[MAV_GOTO]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_GOTO) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_GOTO[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_GOTO {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_GOTO = map[string]MAV_GOTO{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_GOTO) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_GOTO[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_GOTO
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_GOTO {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_GOTO) String() string {
-	if l, ok := labels_MAV_GOTO[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_landed_state.go
+++ b/pkg/dialects/common/enum_mav_landed_state.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Enumeration of landed detector states
@@ -32,27 +33,38 @@ var labels_MAV_LANDED_STATE = map[MAV_LANDED_STATE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_LANDED_STATE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_LANDED_STATE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_LANDED_STATE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_LANDED_STATE = map[string]MAV_LANDED_STATE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_LANDED_STATE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_LANDED_STATE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_LANDED_STATE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_LANDED_STATE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_LANDED_STATE) String() string {
-	if l, ok := labels_MAV_LANDED_STATE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_mission_result.go
+++ b/pkg/dialects/common/enum_mav_mission_result.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Result of mission operation (in a MISSION_ACK message).
@@ -65,27 +66,38 @@ var labels_MAV_MISSION_RESULT = map[MAV_MISSION_RESULT]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MISSION_RESULT) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_MISSION_RESULT[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_MISSION_RESULT {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_MISSION_RESULT = map[string]MAV_MISSION_RESULT{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_MISSION_RESULT) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_MISSION_RESULT[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_MISSION_RESULT
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_MISSION_RESULT {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_MISSION_RESULT) String() string {
-	if l, ok := labels_MAV_MISSION_RESULT[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_mission_type.go
+++ b/pkg/dialects/common/enum_mav_mission_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Type of mission items being requested/sent in mission protocol.
@@ -29,27 +30,38 @@ var labels_MAV_MISSION_TYPE = map[MAV_MISSION_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MISSION_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_MISSION_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_MISSION_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_MISSION_TYPE = map[string]MAV_MISSION_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_MISSION_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_MISSION_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_MISSION_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_MISSION_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_MISSION_TYPE) String() string {
-	if l, ok := labels_MAV_MISSION_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_mode.go
+++ b/pkg/dialects/common/enum_mav_mode.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // These defines are predefined OR-combined mode flags. There is no need to use values from this enum, but it
@@ -51,27 +52,38 @@ var labels_MAV_MODE = map[MAV_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_MODE = map[string]MAV_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_MODE) String() string {
-	if l, ok := labels_MAV_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_mount_mode.go
+++ b/pkg/dialects/common/enum_mav_mount_mode.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Enumeration of possible mount operation modes. This message is used by obsolete/deprecated gimbal messages.
@@ -38,27 +39,38 @@ var labels_MAV_MOUNT_MODE = map[MAV_MOUNT_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MOUNT_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_MOUNT_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_MOUNT_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_MOUNT_MODE = map[string]MAV_MOUNT_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_MOUNT_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_MOUNT_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_MOUNT_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_MOUNT_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_MOUNT_MODE) String() string {
-	if l, ok := labels_MAV_MOUNT_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_arm_status.go
+++ b/pkg/dialects/common/enum_mav_odid_arm_status.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_ARM_STATUS uint32
@@ -22,27 +23,38 @@ var labels_MAV_ODID_ARM_STATUS = map[MAV_ODID_ARM_STATUS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_ARM_STATUS) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_ARM_STATUS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_ARM_STATUS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_ARM_STATUS = map[string]MAV_ODID_ARM_STATUS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_ARM_STATUS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_ARM_STATUS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_ARM_STATUS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_ARM_STATUS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_ARM_STATUS) String() string {
-	if l, ok := labels_MAV_ODID_ARM_STATUS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_auth_type.go
+++ b/pkg/dialects/common/enum_mav_odid_auth_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_AUTH_TYPE uint32
@@ -34,27 +35,38 @@ var labels_MAV_ODID_AUTH_TYPE = map[MAV_ODID_AUTH_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_AUTH_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_AUTH_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_AUTH_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_AUTH_TYPE = map[string]MAV_ODID_AUTH_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_AUTH_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_AUTH_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_AUTH_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_AUTH_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_AUTH_TYPE) String() string {
-	if l, ok := labels_MAV_ODID_AUTH_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_category_eu.go
+++ b/pkg/dialects/common/enum_mav_odid_category_eu.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_CATEGORY_EU uint32
@@ -28,27 +29,38 @@ var labels_MAV_ODID_CATEGORY_EU = map[MAV_ODID_CATEGORY_EU]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_CATEGORY_EU) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_CATEGORY_EU[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_CATEGORY_EU {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_CATEGORY_EU = map[string]MAV_ODID_CATEGORY_EU{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_CATEGORY_EU) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_CATEGORY_EU[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_CATEGORY_EU
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_CATEGORY_EU {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_CATEGORY_EU) String() string {
-	if l, ok := labels_MAV_ODID_CATEGORY_EU[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_class_eu.go
+++ b/pkg/dialects/common/enum_mav_odid_class_eu.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_CLASS_EU uint32
@@ -40,27 +41,38 @@ var labels_MAV_ODID_CLASS_EU = map[MAV_ODID_CLASS_EU]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_CLASS_EU) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_CLASS_EU[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_CLASS_EU {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_CLASS_EU = map[string]MAV_ODID_CLASS_EU{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_CLASS_EU) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_CLASS_EU[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_CLASS_EU
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_CLASS_EU {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_CLASS_EU) String() string {
-	if l, ok := labels_MAV_ODID_CLASS_EU[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_classification_type.go
+++ b/pkg/dialects/common/enum_mav_odid_classification_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_CLASSIFICATION_TYPE uint32
@@ -22,27 +23,38 @@ var labels_MAV_ODID_CLASSIFICATION_TYPE = map[MAV_ODID_CLASSIFICATION_TYPE]strin
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_CLASSIFICATION_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_CLASSIFICATION_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_CLASSIFICATION_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_CLASSIFICATION_TYPE = map[string]MAV_ODID_CLASSIFICATION_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_CLASSIFICATION_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_CLASSIFICATION_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_CLASSIFICATION_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_CLASSIFICATION_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_CLASSIFICATION_TYPE) String() string {
-	if l, ok := labels_MAV_ODID_CLASSIFICATION_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_desc_type.go
+++ b/pkg/dialects/common/enum_mav_odid_desc_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_DESC_TYPE uint32
@@ -25,27 +26,38 @@ var labels_MAV_ODID_DESC_TYPE = map[MAV_ODID_DESC_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_DESC_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_DESC_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_DESC_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_DESC_TYPE = map[string]MAV_ODID_DESC_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_DESC_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_DESC_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_DESC_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_DESC_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_DESC_TYPE) String() string {
-	if l, ok := labels_MAV_ODID_DESC_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_height_ref.go
+++ b/pkg/dialects/common/enum_mav_odid_height_ref.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_HEIGHT_REF uint32
@@ -22,27 +23,38 @@ var labels_MAV_ODID_HEIGHT_REF = map[MAV_ODID_HEIGHT_REF]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_HEIGHT_REF) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_HEIGHT_REF[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_HEIGHT_REF {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_HEIGHT_REF = map[string]MAV_ODID_HEIGHT_REF{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_HEIGHT_REF) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_HEIGHT_REF[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_HEIGHT_REF
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_HEIGHT_REF {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_HEIGHT_REF) String() string {
-	if l, ok := labels_MAV_ODID_HEIGHT_REF[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_hor_acc.go
+++ b/pkg/dialects/common/enum_mav_odid_hor_acc.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_HOR_ACC uint32
@@ -55,27 +56,38 @@ var labels_MAV_ODID_HOR_ACC = map[MAV_ODID_HOR_ACC]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_HOR_ACC) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_HOR_ACC[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_HOR_ACC {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_HOR_ACC = map[string]MAV_ODID_HOR_ACC{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_HOR_ACC) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_HOR_ACC[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_HOR_ACC
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_HOR_ACC {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_HOR_ACC) String() string {
-	if l, ok := labels_MAV_ODID_HOR_ACC[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_id_type.go
+++ b/pkg/dialects/common/enum_mav_odid_id_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_ID_TYPE uint32
@@ -31,27 +32,38 @@ var labels_MAV_ODID_ID_TYPE = map[MAV_ODID_ID_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_ID_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_ID_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_ID_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_ID_TYPE = map[string]MAV_ODID_ID_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_ID_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_ID_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_ID_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_ID_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_ID_TYPE) String() string {
-	if l, ok := labels_MAV_ODID_ID_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_operator_id_type.go
+++ b/pkg/dialects/common/enum_mav_odid_operator_id_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_OPERATOR_ID_TYPE uint32
@@ -19,27 +20,38 @@ var labels_MAV_ODID_OPERATOR_ID_TYPE = map[MAV_ODID_OPERATOR_ID_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_OPERATOR_ID_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_OPERATOR_ID_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_OPERATOR_ID_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_OPERATOR_ID_TYPE = map[string]MAV_ODID_OPERATOR_ID_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_OPERATOR_ID_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_OPERATOR_ID_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_OPERATOR_ID_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_OPERATOR_ID_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_OPERATOR_ID_TYPE) String() string {
-	if l, ok := labels_MAV_ODID_OPERATOR_ID_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_operator_location_type.go
+++ b/pkg/dialects/common/enum_mav_odid_operator_location_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_OPERATOR_LOCATION_TYPE uint32
@@ -25,27 +26,38 @@ var labels_MAV_ODID_OPERATOR_LOCATION_TYPE = map[MAV_ODID_OPERATOR_LOCATION_TYPE
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_OPERATOR_LOCATION_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_OPERATOR_LOCATION_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_OPERATOR_LOCATION_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_OPERATOR_LOCATION_TYPE = map[string]MAV_ODID_OPERATOR_LOCATION_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_OPERATOR_LOCATION_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_OPERATOR_LOCATION_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_OPERATOR_LOCATION_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_OPERATOR_LOCATION_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_OPERATOR_LOCATION_TYPE) String() string {
-	if l, ok := labels_MAV_ODID_OPERATOR_LOCATION_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_speed_acc.go
+++ b/pkg/dialects/common/enum_mav_odid_speed_acc.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_SPEED_ACC uint32
@@ -31,27 +32,38 @@ var labels_MAV_ODID_SPEED_ACC = map[MAV_ODID_SPEED_ACC]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_SPEED_ACC) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_SPEED_ACC[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_SPEED_ACC {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_SPEED_ACC = map[string]MAV_ODID_SPEED_ACC{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_SPEED_ACC) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_SPEED_ACC[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_SPEED_ACC
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_SPEED_ACC {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_SPEED_ACC) String() string {
-	if l, ok := labels_MAV_ODID_SPEED_ACC[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_status.go
+++ b/pkg/dialects/common/enum_mav_odid_status.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_STATUS uint32
@@ -31,27 +32,38 @@ var labels_MAV_ODID_STATUS = map[MAV_ODID_STATUS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_STATUS) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_STATUS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_STATUS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_STATUS = map[string]MAV_ODID_STATUS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_STATUS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_STATUS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_STATUS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_STATUS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_STATUS) String() string {
-	if l, ok := labels_MAV_ODID_STATUS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_time_acc.go
+++ b/pkg/dialects/common/enum_mav_odid_time_acc.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_TIME_ACC uint32
@@ -64,27 +65,38 @@ var labels_MAV_ODID_TIME_ACC = map[MAV_ODID_TIME_ACC]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_TIME_ACC) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_TIME_ACC[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_TIME_ACC {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_TIME_ACC = map[string]MAV_ODID_TIME_ACC{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_TIME_ACC) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_TIME_ACC[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_TIME_ACC
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_TIME_ACC {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_TIME_ACC) String() string {
-	if l, ok := labels_MAV_ODID_TIME_ACC[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_ua_type.go
+++ b/pkg/dialects/common/enum_mav_odid_ua_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_UA_TYPE uint32
@@ -64,27 +65,38 @@ var labels_MAV_ODID_UA_TYPE = map[MAV_ODID_UA_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_UA_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_UA_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_UA_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_UA_TYPE = map[string]MAV_ODID_UA_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_UA_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_UA_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_UA_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_UA_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_UA_TYPE) String() string {
-	if l, ok := labels_MAV_ODID_UA_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_odid_ver_acc.go
+++ b/pkg/dialects/common/enum_mav_odid_ver_acc.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_ODID_VER_ACC uint32
@@ -37,27 +38,38 @@ var labels_MAV_ODID_VER_ACC = map[MAV_ODID_VER_ACC]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_VER_ACC) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ODID_VER_ACC[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ODID_VER_ACC {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ODID_VER_ACC = map[string]MAV_ODID_VER_ACC{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_VER_ACC) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ODID_VER_ACC[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ODID_VER_ACC
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ODID_VER_ACC {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_VER_ACC) String() string {
-	if l, ok := labels_MAV_ODID_VER_ACC[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_param_ext_type.go
+++ b/pkg/dialects/common/enum_mav_param_ext_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Specifies the datatype of a MAVLink extended parameter.
@@ -50,27 +51,38 @@ var labels_MAV_PARAM_EXT_TYPE = map[MAV_PARAM_EXT_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_PARAM_EXT_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_PARAM_EXT_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_PARAM_EXT_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_PARAM_EXT_TYPE = map[string]MAV_PARAM_EXT_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_PARAM_EXT_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_PARAM_EXT_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_PARAM_EXT_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_PARAM_EXT_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_PARAM_EXT_TYPE) String() string {
-	if l, ok := labels_MAV_PARAM_EXT_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_param_type.go
+++ b/pkg/dialects/common/enum_mav_param_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Specifies the datatype of a MAVLink parameter.
@@ -47,27 +48,38 @@ var labels_MAV_PARAM_TYPE = map[MAV_PARAM_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_PARAM_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_PARAM_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_PARAM_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_PARAM_TYPE = map[string]MAV_PARAM_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_PARAM_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_PARAM_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_PARAM_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_PARAM_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_PARAM_TYPE) String() string {
-	if l, ok := labels_MAV_PARAM_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_result.go
+++ b/pkg/dialects/common/enum_mav_result.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Result from a MAVLink command (MAV_CMD)
@@ -38,27 +39,38 @@ var labels_MAV_RESULT = map[MAV_RESULT]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_RESULT) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_RESULT[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_RESULT {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_RESULT = map[string]MAV_RESULT{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_RESULT) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_RESULT[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_RESULT
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_RESULT {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_RESULT) String() string {
-	if l, ok := labels_MAV_RESULT[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_roi.go
+++ b/pkg/dialects/common/enum_mav_roi.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // The ROI (region of interest) for the vehicle. This can be
@@ -34,27 +35,38 @@ var labels_MAV_ROI = map[MAV_ROI]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ROI) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_ROI[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_ROI {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_ROI = map[string]MAV_ROI{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ROI) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_ROI[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_ROI
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_ROI {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ROI) String() string {
-	if l, ok := labels_MAV_ROI[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_sensor_orientation.go
+++ b/pkg/dialects/common/enum_mav_sensor_orientation.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Enumeration of sensor orientation, according to its rotations
@@ -143,27 +144,38 @@ var labels_MAV_SENSOR_ORIENTATION = map[MAV_SENSOR_ORIENTATION]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_SENSOR_ORIENTATION) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_SENSOR_ORIENTATION[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_SENSOR_ORIENTATION {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_SENSOR_ORIENTATION = map[string]MAV_SENSOR_ORIENTATION{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_SENSOR_ORIENTATION) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_SENSOR_ORIENTATION[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_SENSOR_ORIENTATION
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_SENSOR_ORIENTATION {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_SENSOR_ORIENTATION) String() string {
-	if l, ok := labels_MAV_SENSOR_ORIENTATION[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_severity.go
+++ b/pkg/dialects/common/enum_mav_severity.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Indicates the severity level, generally used for status messages to indicate their relative urgency. Based on RFC-5424 using expanded definitions at: http://www.kiwisyslog.com/kb/info:-syslog-message-levels/.
@@ -41,27 +42,38 @@ var labels_MAV_SEVERITY = map[MAV_SEVERITY]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_SEVERITY) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_SEVERITY[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_SEVERITY {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_SEVERITY = map[string]MAV_SEVERITY{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_SEVERITY) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_SEVERITY[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_SEVERITY
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_SEVERITY {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_SEVERITY) String() string {
-	if l, ok := labels_MAV_SEVERITY[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_sys_status_sensor.go
+++ b/pkg/dialects/common/enum_mav_sys_status_sensor.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // These encode the sensors whose status is sent as part of the SYS_STATUS message.
@@ -113,27 +114,38 @@ var labels_MAV_SYS_STATUS_SENSOR = map[MAV_SYS_STATUS_SENSOR]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_SYS_STATUS_SENSOR) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_SYS_STATUS_SENSOR[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_SYS_STATUS_SENSOR {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_SYS_STATUS_SENSOR = map[string]MAV_SYS_STATUS_SENSOR{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_SYS_STATUS_SENSOR) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_SYS_STATUS_SENSOR[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_SYS_STATUS_SENSOR
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_SYS_STATUS_SENSOR {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_SYS_STATUS_SENSOR) String() string {
-	if l, ok := labels_MAV_SYS_STATUS_SENSOR[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_sys_status_sensor_extended.go
+++ b/pkg/dialects/common/enum_mav_sys_status_sensor_extended.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // These encode the sensors whose status is sent as part of the SYS_STATUS message in the extended fields.
@@ -20,27 +21,38 @@ var labels_MAV_SYS_STATUS_SENSOR_EXTENDED = map[MAV_SYS_STATUS_SENSOR_EXTENDED]s
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_SYS_STATUS_SENSOR_EXTENDED) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_SYS_STATUS_SENSOR_EXTENDED[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_SYS_STATUS_SENSOR_EXTENDED {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_SYS_STATUS_SENSOR_EXTENDED = map[string]MAV_SYS_STATUS_SENSOR_EXTENDED{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_SYS_STATUS_SENSOR_EXTENDED) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_SYS_STATUS_SENSOR_EXTENDED[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_SYS_STATUS_SENSOR_EXTENDED
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_SYS_STATUS_SENSOR_EXTENDED {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_SYS_STATUS_SENSOR_EXTENDED) String() string {
-	if l, ok := labels_MAV_SYS_STATUS_SENSOR_EXTENDED[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_tunnel_payload_type.go
+++ b/pkg/dialects/common/enum_mav_tunnel_payload_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_TUNNEL_PAYLOAD_TYPE uint32
@@ -49,27 +50,38 @@ var labels_MAV_TUNNEL_PAYLOAD_TYPE = map[MAV_TUNNEL_PAYLOAD_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_TUNNEL_PAYLOAD_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_TUNNEL_PAYLOAD_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_TUNNEL_PAYLOAD_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_TUNNEL_PAYLOAD_TYPE = map[string]MAV_TUNNEL_PAYLOAD_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_TUNNEL_PAYLOAD_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_TUNNEL_PAYLOAD_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_TUNNEL_PAYLOAD_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_TUNNEL_PAYLOAD_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_TUNNEL_PAYLOAD_TYPE) String() string {
-	if l, ok := labels_MAV_TUNNEL_PAYLOAD_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_vtol_state.go
+++ b/pkg/dialects/common/enum_mav_vtol_state.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Enumeration of VTOL states
@@ -32,27 +33,38 @@ var labels_MAV_VTOL_STATE = map[MAV_VTOL_STATE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_VTOL_STATE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_VTOL_STATE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_VTOL_STATE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_VTOL_STATE = map[string]MAV_VTOL_STATE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_VTOL_STATE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_VTOL_STATE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_VTOL_STATE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_VTOL_STATE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_VTOL_STATE) String() string {
-	if l, ok := labels_MAV_VTOL_STATE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mav_winch_status_flag.go
+++ b/pkg/dialects/common/enum_mav_winch_status_flag.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Winch status flags used in WINCH_STATUS
@@ -59,27 +60,38 @@ var labels_MAV_WINCH_STATUS_FLAG = map[MAV_WINCH_STATUS_FLAG]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_WINCH_STATUS_FLAG) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_WINCH_STATUS_FLAG[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_WINCH_STATUS_FLAG {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_WINCH_STATUS_FLAG = map[string]MAV_WINCH_STATUS_FLAG{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_WINCH_STATUS_FLAG) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_WINCH_STATUS_FLAG[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_WINCH_STATUS_FLAG
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_WINCH_STATUS_FLAG {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_WINCH_STATUS_FLAG) String() string {
-	if l, ok := labels_MAV_WINCH_STATUS_FLAG[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mavlink_data_stream_type.go
+++ b/pkg/dialects/common/enum_mavlink_data_stream_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAVLINK_DATA_STREAM_TYPE uint32
@@ -28,27 +29,38 @@ var labels_MAVLINK_DATA_STREAM_TYPE = map[MAVLINK_DATA_STREAM_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAVLINK_DATA_STREAM_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAVLINK_DATA_STREAM_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAVLINK_DATA_STREAM_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAVLINK_DATA_STREAM_TYPE = map[string]MAVLINK_DATA_STREAM_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAVLINK_DATA_STREAM_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAVLINK_DATA_STREAM_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAVLINK_DATA_STREAM_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAVLINK_DATA_STREAM_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAVLINK_DATA_STREAM_TYPE) String() string {
-	if l, ok := labels_MAVLINK_DATA_STREAM_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_mission_state.go
+++ b/pkg/dialects/common/enum_mission_state.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // States of the mission state machine.
@@ -37,27 +38,38 @@ var labels_MISSION_STATE = map[MISSION_STATE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MISSION_STATE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MISSION_STATE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MISSION_STATE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MISSION_STATE = map[string]MISSION_STATE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MISSION_STATE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MISSION_STATE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MISSION_STATE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MISSION_STATE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MISSION_STATE) String() string {
-	if l, ok := labels_MISSION_STATE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_motor_test_throttle_type.go
+++ b/pkg/dialects/common/enum_motor_test_throttle_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Defines how throttle value is represented in MAV_CMD_DO_MOTOR_TEST.
@@ -29,27 +30,38 @@ var labels_MOTOR_TEST_THROTTLE_TYPE = map[MOTOR_TEST_THROTTLE_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MOTOR_TEST_THROTTLE_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MOTOR_TEST_THROTTLE_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MOTOR_TEST_THROTTLE_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MOTOR_TEST_THROTTLE_TYPE = map[string]MOTOR_TEST_THROTTLE_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MOTOR_TEST_THROTTLE_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MOTOR_TEST_THROTTLE_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MOTOR_TEST_THROTTLE_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MOTOR_TEST_THROTTLE_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MOTOR_TEST_THROTTLE_TYPE) String() string {
-	if l, ok := labels_MOTOR_TEST_THROTTLE_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_nav_vtol_land_options.go
+++ b/pkg/dialects/common/enum_nav_vtol_land_options.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type NAV_VTOL_LAND_OPTIONS uint32
@@ -26,27 +27,38 @@ var labels_NAV_VTOL_LAND_OPTIONS = map[NAV_VTOL_LAND_OPTIONS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e NAV_VTOL_LAND_OPTIONS) MarshalText() ([]byte, error) {
-	if l, ok := labels_NAV_VTOL_LAND_OPTIONS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_NAV_VTOL_LAND_OPTIONS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_NAV_VTOL_LAND_OPTIONS = map[string]NAV_VTOL_LAND_OPTIONS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *NAV_VTOL_LAND_OPTIONS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_NAV_VTOL_LAND_OPTIONS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask NAV_VTOL_LAND_OPTIONS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_NAV_VTOL_LAND_OPTIONS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e NAV_VTOL_LAND_OPTIONS) String() string {
-	if l, ok := labels_NAV_VTOL_LAND_OPTIONS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_orbit_yaw_behaviour.go
+++ b/pkg/dialects/common/enum_orbit_yaw_behaviour.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Yaw behaviour during orbit flight.
@@ -32,27 +33,38 @@ var labels_ORBIT_YAW_BEHAVIOUR = map[ORBIT_YAW_BEHAVIOUR]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ORBIT_YAW_BEHAVIOUR) MarshalText() ([]byte, error) {
-	if l, ok := labels_ORBIT_YAW_BEHAVIOUR[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_ORBIT_YAW_BEHAVIOUR {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_ORBIT_YAW_BEHAVIOUR = map[string]ORBIT_YAW_BEHAVIOUR{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ORBIT_YAW_BEHAVIOUR) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_ORBIT_YAW_BEHAVIOUR[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask ORBIT_YAW_BEHAVIOUR
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_ORBIT_YAW_BEHAVIOUR {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ORBIT_YAW_BEHAVIOUR) String() string {
-	if l, ok := labels_ORBIT_YAW_BEHAVIOUR[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_parachute_action.go
+++ b/pkg/dialects/common/enum_parachute_action.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Parachute actions. Trigger release and enable/disable auto-release.
@@ -26,27 +27,38 @@ var labels_PARACHUTE_ACTION = map[PARACHUTE_ACTION]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PARACHUTE_ACTION) MarshalText() ([]byte, error) {
-	if l, ok := labels_PARACHUTE_ACTION[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_PARACHUTE_ACTION {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_PARACHUTE_ACTION = map[string]PARACHUTE_ACTION{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PARACHUTE_ACTION) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_PARACHUTE_ACTION[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask PARACHUTE_ACTION
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_PARACHUTE_ACTION {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PARACHUTE_ACTION) String() string {
-	if l, ok := labels_PARACHUTE_ACTION[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_param_ack.go
+++ b/pkg/dialects/common/enum_param_ack.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Result from PARAM_EXT_SET message (or a PARAM_SET within a transaction).
@@ -29,27 +30,38 @@ var labels_PARAM_ACK = map[PARAM_ACK]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PARAM_ACK) MarshalText() ([]byte, error) {
-	if l, ok := labels_PARAM_ACK[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_PARAM_ACK {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_PARAM_ACK = map[string]PARAM_ACK{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PARAM_ACK) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_PARAM_ACK[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask PARAM_ACK
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_PARAM_ACK {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PARAM_ACK) String() string {
-	if l, ok := labels_PARAM_ACK[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_precision_land_mode.go
+++ b/pkg/dialects/common/enum_precision_land_mode.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Precision land modes (used in MAV_CMD_NAV_LAND).
@@ -26,27 +27,38 @@ var labels_PRECISION_LAND_MODE = map[PRECISION_LAND_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PRECISION_LAND_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_PRECISION_LAND_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_PRECISION_LAND_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_PRECISION_LAND_MODE = map[string]PRECISION_LAND_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PRECISION_LAND_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_PRECISION_LAND_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask PRECISION_LAND_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_PRECISION_LAND_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PRECISION_LAND_MODE) String() string {
-	if l, ok := labels_PRECISION_LAND_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_preflight_storage_mission_action.go
+++ b/pkg/dialects/common/enum_preflight_storage_mission_action.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Actions for reading and writing plan information (mission, rally points, geofence) between persistent and volatile storage when using MAV_CMD_PREFLIGHT_STORAGE.
@@ -27,27 +28,38 @@ var labels_PREFLIGHT_STORAGE_MISSION_ACTION = map[PREFLIGHT_STORAGE_MISSION_ACTI
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PREFLIGHT_STORAGE_MISSION_ACTION) MarshalText() ([]byte, error) {
-	if l, ok := labels_PREFLIGHT_STORAGE_MISSION_ACTION[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_PREFLIGHT_STORAGE_MISSION_ACTION {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_PREFLIGHT_STORAGE_MISSION_ACTION = map[string]PREFLIGHT_STORAGE_MISSION_ACTION{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PREFLIGHT_STORAGE_MISSION_ACTION) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_PREFLIGHT_STORAGE_MISSION_ACTION[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask PREFLIGHT_STORAGE_MISSION_ACTION
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_PREFLIGHT_STORAGE_MISSION_ACTION {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PREFLIGHT_STORAGE_MISSION_ACTION) String() string {
-	if l, ok := labels_PREFLIGHT_STORAGE_MISSION_ACTION[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_preflight_storage_parameter_action.go
+++ b/pkg/dialects/common/enum_preflight_storage_parameter_action.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Actions for reading/writing parameters between persistent and volatile storage when using MAV_CMD_PREFLIGHT_STORAGE.
@@ -33,27 +34,38 @@ var labels_PREFLIGHT_STORAGE_PARAMETER_ACTION = map[PREFLIGHT_STORAGE_PARAMETER_
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PREFLIGHT_STORAGE_PARAMETER_ACTION) MarshalText() ([]byte, error) {
-	if l, ok := labels_PREFLIGHT_STORAGE_PARAMETER_ACTION[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_PREFLIGHT_STORAGE_PARAMETER_ACTION {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_PREFLIGHT_STORAGE_PARAMETER_ACTION = map[string]PREFLIGHT_STORAGE_PARAMETER_ACTION{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PREFLIGHT_STORAGE_PARAMETER_ACTION) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_PREFLIGHT_STORAGE_PARAMETER_ACTION[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask PREFLIGHT_STORAGE_PARAMETER_ACTION
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_PREFLIGHT_STORAGE_PARAMETER_ACTION {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PREFLIGHT_STORAGE_PARAMETER_ACTION) String() string {
-	if l, ok := labels_PREFLIGHT_STORAGE_PARAMETER_ACTION[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_rc_type.go
+++ b/pkg/dialects/common/enum_rc_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // RC type
@@ -23,27 +24,38 @@ var labels_RC_TYPE = map[RC_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e RC_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_RC_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_RC_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_RC_TYPE = map[string]RC_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *RC_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_RC_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask RC_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_RC_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e RC_TYPE) String() string {
-	if l, ok := labels_RC_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_rtk_baseline_coordinate_system.go
+++ b/pkg/dialects/common/enum_rtk_baseline_coordinate_system.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // RTK GPS baseline coordinate system, used for RTK corrections
@@ -23,27 +24,38 @@ var labels_RTK_BASELINE_COORDINATE_SYSTEM = map[RTK_BASELINE_COORDINATE_SYSTEM]s
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e RTK_BASELINE_COORDINATE_SYSTEM) MarshalText() ([]byte, error) {
-	if l, ok := labels_RTK_BASELINE_COORDINATE_SYSTEM[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_RTK_BASELINE_COORDINATE_SYSTEM {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_RTK_BASELINE_COORDINATE_SYSTEM = map[string]RTK_BASELINE_COORDINATE_SYSTEM{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *RTK_BASELINE_COORDINATE_SYSTEM) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_RTK_BASELINE_COORDINATE_SYSTEM[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask RTK_BASELINE_COORDINATE_SYSTEM
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_RTK_BASELINE_COORDINATE_SYSTEM {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e RTK_BASELINE_COORDINATE_SYSTEM) String() string {
-	if l, ok := labels_RTK_BASELINE_COORDINATE_SYSTEM[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_serial_control_dev.go
+++ b/pkg/dialects/common/enum_serial_control_dev.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // SERIAL_CONTROL device types
@@ -62,27 +63,38 @@ var labels_SERIAL_CONTROL_DEV = map[SERIAL_CONTROL_DEV]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e SERIAL_CONTROL_DEV) MarshalText() ([]byte, error) {
-	if l, ok := labels_SERIAL_CONTROL_DEV[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_SERIAL_CONTROL_DEV {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_SERIAL_CONTROL_DEV = map[string]SERIAL_CONTROL_DEV{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *SERIAL_CONTROL_DEV) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_SERIAL_CONTROL_DEV[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask SERIAL_CONTROL_DEV
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_SERIAL_CONTROL_DEV {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e SERIAL_CONTROL_DEV) String() string {
-	if l, ok := labels_SERIAL_CONTROL_DEV[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_serial_control_flag.go
+++ b/pkg/dialects/common/enum_serial_control_flag.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // SERIAL_CONTROL flags (bitmask)
@@ -32,27 +33,38 @@ var labels_SERIAL_CONTROL_FLAG = map[SERIAL_CONTROL_FLAG]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e SERIAL_CONTROL_FLAG) MarshalText() ([]byte, error) {
-	if l, ok := labels_SERIAL_CONTROL_FLAG[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_SERIAL_CONTROL_FLAG {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_SERIAL_CONTROL_FLAG = map[string]SERIAL_CONTROL_FLAG{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *SERIAL_CONTROL_FLAG) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_SERIAL_CONTROL_FLAG[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask SERIAL_CONTROL_FLAG
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_SERIAL_CONTROL_FLAG {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e SERIAL_CONTROL_FLAG) String() string {
-	if l, ok := labels_SERIAL_CONTROL_FLAG[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_set_focus_type.go
+++ b/pkg/dialects/common/enum_set_focus_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Focus types for MAV_CMD_SET_CAMERA_FOCUS
@@ -38,27 +39,38 @@ var labels_SET_FOCUS_TYPE = map[SET_FOCUS_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e SET_FOCUS_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_SET_FOCUS_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_SET_FOCUS_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_SET_FOCUS_TYPE = map[string]SET_FOCUS_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *SET_FOCUS_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_SET_FOCUS_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask SET_FOCUS_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_SET_FOCUS_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e SET_FOCUS_TYPE) String() string {
-	if l, ok := labels_SET_FOCUS_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_storage_type.go
+++ b/pkg/dialects/common/enum_storage_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Flags to indicate the type of storage.
@@ -44,27 +45,38 @@ var labels_STORAGE_TYPE = map[STORAGE_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e STORAGE_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_STORAGE_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_STORAGE_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_STORAGE_TYPE = map[string]STORAGE_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *STORAGE_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_STORAGE_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask STORAGE_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_STORAGE_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e STORAGE_TYPE) String() string {
-	if l, ok := labels_STORAGE_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_storage_usage_flag.go
+++ b/pkg/dialects/common/enum_storage_usage_flag.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Flags to indicate usage for a particular storage (see STORAGE_INFORMATION.storage_usage and MAV_CMD_SET_STORAGE_USAGE).
@@ -29,27 +30,38 @@ var labels_STORAGE_USAGE_FLAG = map[STORAGE_USAGE_FLAG]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e STORAGE_USAGE_FLAG) MarshalText() ([]byte, error) {
-	if l, ok := labels_STORAGE_USAGE_FLAG[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_STORAGE_USAGE_FLAG {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_STORAGE_USAGE_FLAG = map[string]STORAGE_USAGE_FLAG{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *STORAGE_USAGE_FLAG) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_STORAGE_USAGE_FLAG[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask STORAGE_USAGE_FLAG
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_STORAGE_USAGE_FLAG {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e STORAGE_USAGE_FLAG) String() string {
-	if l, ok := labels_STORAGE_USAGE_FLAG[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_uavcan_node_health.go
+++ b/pkg/dialects/common/enum_uavcan_node_health.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Generalized UAVCAN node health
@@ -29,27 +30,38 @@ var labels_UAVCAN_NODE_HEALTH = map[UAVCAN_NODE_HEALTH]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVCAN_NODE_HEALTH) MarshalText() ([]byte, error) {
-	if l, ok := labels_UAVCAN_NODE_HEALTH[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_UAVCAN_NODE_HEALTH {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_UAVCAN_NODE_HEALTH = map[string]UAVCAN_NODE_HEALTH{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVCAN_NODE_HEALTH) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_UAVCAN_NODE_HEALTH[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask UAVCAN_NODE_HEALTH
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_UAVCAN_NODE_HEALTH {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVCAN_NODE_HEALTH) String() string {
-	if l, ok := labels_UAVCAN_NODE_HEALTH[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_uavcan_node_mode.go
+++ b/pkg/dialects/common/enum_uavcan_node_mode.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Generalized UAVCAN node mode
@@ -32,27 +33,38 @@ var labels_UAVCAN_NODE_MODE = map[UAVCAN_NODE_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVCAN_NODE_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_UAVCAN_NODE_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_UAVCAN_NODE_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_UAVCAN_NODE_MODE = map[string]UAVCAN_NODE_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVCAN_NODE_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_UAVCAN_NODE_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask UAVCAN_NODE_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_UAVCAN_NODE_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVCAN_NODE_MODE) String() string {
-	if l, ok := labels_UAVCAN_NODE_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_utm_flight_state.go
+++ b/pkg/dialects/common/enum_utm_flight_state.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Airborne status of UAS.
@@ -32,27 +33,38 @@ var labels_UTM_FLIGHT_STATE = map[UTM_FLIGHT_STATE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UTM_FLIGHT_STATE) MarshalText() ([]byte, error) {
-	if l, ok := labels_UTM_FLIGHT_STATE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_UTM_FLIGHT_STATE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_UTM_FLIGHT_STATE = map[string]UTM_FLIGHT_STATE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UTM_FLIGHT_STATE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_UTM_FLIGHT_STATE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask UTM_FLIGHT_STATE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_UTM_FLIGHT_STATE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UTM_FLIGHT_STATE) String() string {
-	if l, ok := labels_UTM_FLIGHT_STATE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_video_stream_status_flags.go
+++ b/pkg/dialects/common/enum_video_stream_status_flags.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Stream status flags (Bitmap)
@@ -23,27 +24,38 @@ var labels_VIDEO_STREAM_STATUS_FLAGS = map[VIDEO_STREAM_STATUS_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e VIDEO_STREAM_STATUS_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_VIDEO_STREAM_STATUS_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_VIDEO_STREAM_STATUS_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_VIDEO_STREAM_STATUS_FLAGS = map[string]VIDEO_STREAM_STATUS_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *VIDEO_STREAM_STATUS_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_VIDEO_STREAM_STATUS_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask VIDEO_STREAM_STATUS_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_VIDEO_STREAM_STATUS_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e VIDEO_STREAM_STATUS_FLAGS) String() string {
-	if l, ok := labels_VIDEO_STREAM_STATUS_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_video_stream_type.go
+++ b/pkg/dialects/common/enum_video_stream_type.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Video stream types
@@ -29,27 +30,38 @@ var labels_VIDEO_STREAM_TYPE = map[VIDEO_STREAM_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e VIDEO_STREAM_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_VIDEO_STREAM_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_VIDEO_STREAM_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_VIDEO_STREAM_TYPE = map[string]VIDEO_STREAM_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *VIDEO_STREAM_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_VIDEO_STREAM_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask VIDEO_STREAM_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_VIDEO_STREAM_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e VIDEO_STREAM_TYPE) String() string {
-	if l, ok := labels_VIDEO_STREAM_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_vtol_transition_heading.go
+++ b/pkg/dialects/common/enum_vtol_transition_heading.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Direction of VTOL transition
@@ -32,27 +33,38 @@ var labels_VTOL_TRANSITION_HEADING = map[VTOL_TRANSITION_HEADING]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e VTOL_TRANSITION_HEADING) MarshalText() ([]byte, error) {
-	if l, ok := labels_VTOL_TRANSITION_HEADING[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_VTOL_TRANSITION_HEADING {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_VTOL_TRANSITION_HEADING = map[string]VTOL_TRANSITION_HEADING{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *VTOL_TRANSITION_HEADING) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_VTOL_TRANSITION_HEADING[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask VTOL_TRANSITION_HEADING
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_VTOL_TRANSITION_HEADING {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e VTOL_TRANSITION_HEADING) String() string {
-	if l, ok := labels_VTOL_TRANSITION_HEADING[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_wifi_config_ap_mode.go
+++ b/pkg/dialects/common/enum_wifi_config_ap_mode.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // WiFi Mode.
@@ -29,27 +30,38 @@ var labels_WIFI_CONFIG_AP_MODE = map[WIFI_CONFIG_AP_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e WIFI_CONFIG_AP_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_WIFI_CONFIG_AP_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_WIFI_CONFIG_AP_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_WIFI_CONFIG_AP_MODE = map[string]WIFI_CONFIG_AP_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *WIFI_CONFIG_AP_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_WIFI_CONFIG_AP_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask WIFI_CONFIG_AP_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_WIFI_CONFIG_AP_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e WIFI_CONFIG_AP_MODE) String() string {
-	if l, ok := labels_WIFI_CONFIG_AP_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_wifi_config_ap_response.go
+++ b/pkg/dialects/common/enum_wifi_config_ap_response.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Possible responses from a WIFI_CONFIG_AP message.
@@ -35,27 +36,38 @@ var labels_WIFI_CONFIG_AP_RESPONSE = map[WIFI_CONFIG_AP_RESPONSE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e WIFI_CONFIG_AP_RESPONSE) MarshalText() ([]byte, error) {
-	if l, ok := labels_WIFI_CONFIG_AP_RESPONSE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_WIFI_CONFIG_AP_RESPONSE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_WIFI_CONFIG_AP_RESPONSE = map[string]WIFI_CONFIG_AP_RESPONSE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *WIFI_CONFIG_AP_RESPONSE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_WIFI_CONFIG_AP_RESPONSE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask WIFI_CONFIG_AP_RESPONSE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_WIFI_CONFIG_AP_RESPONSE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e WIFI_CONFIG_AP_RESPONSE) String() string {
-	if l, ok := labels_WIFI_CONFIG_AP_RESPONSE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/common/enum_winch_actions.go
+++ b/pkg/dialects/common/enum_winch_actions.go
@@ -3,7 +3,8 @@
 package common
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Winch actions.
@@ -47,27 +48,38 @@ var labels_WINCH_ACTIONS = map[WINCH_ACTIONS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e WINCH_ACTIONS) MarshalText() ([]byte, error) {
-	if l, ok := labels_WINCH_ACTIONS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_WINCH_ACTIONS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_WINCH_ACTIONS = map[string]WINCH_ACTIONS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *WINCH_ACTIONS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_WINCH_ACTIONS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask WINCH_ACTIONS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_WINCH_ACTIONS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e WINCH_ACTIONS) String() string {
-	if l, ok := labels_WINCH_ACTIONS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/development/enum_airspeed_sensor_flags.go
+++ b/pkg/dialects/development/enum_airspeed_sensor_flags.go
@@ -3,7 +3,8 @@
 package development
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Airspeed sensor flags
@@ -23,27 +24,38 @@ var labels_AIRSPEED_SENSOR_FLAGS = map[AIRSPEED_SENSOR_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e AIRSPEED_SENSOR_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_AIRSPEED_SENSOR_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_AIRSPEED_SENSOR_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_AIRSPEED_SENSOR_FLAGS = map[string]AIRSPEED_SENSOR_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *AIRSPEED_SENSOR_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_AIRSPEED_SENSOR_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask AIRSPEED_SENSOR_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_AIRSPEED_SENSOR_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e AIRSPEED_SENSOR_FLAGS) String() string {
-	if l, ok := labels_AIRSPEED_SENSOR_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/development/enum_mav_battery_status_flags.go
+++ b/pkg/dialects/development/enum_mav_battery_status_flags.go
@@ -3,7 +3,8 @@
 package development
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Battery status flags for fault, health and state indication.
@@ -96,27 +97,38 @@ var labels_MAV_BATTERY_STATUS_FLAGS = map[MAV_BATTERY_STATUS_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_BATTERY_STATUS_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_BATTERY_STATUS_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_BATTERY_STATUS_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_BATTERY_STATUS_FLAGS = map[string]MAV_BATTERY_STATUS_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_BATTERY_STATUS_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_BATTERY_STATUS_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_BATTERY_STATUS_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_BATTERY_STATUS_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_BATTERY_STATUS_FLAGS) String() string {
-	if l, ok := labels_MAV_BATTERY_STATUS_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/development/enum_mav_cmd.go
+++ b/pkg/dialects/development/enum_mav_cmd.go
@@ -3,7 +3,8 @@
 package development
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data. NaN and INT32_MAX may be used in float/integer params (respectively) to indicate optional/default values (e.g. to use the component's current yaw or latitude rather than a specific value). See https://mavlink.io/en/guide/xml_schema.html#MAV_CMD for information about the structure of the MAV_CMD entries
@@ -568,27 +569,38 @@ var labels_MAV_CMD = map[MAV_CMD]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_CMD[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_CMD {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_CMD = map[string]MAV_CMD{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_CMD[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_CMD
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_CMD {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD) String() string {
-	if l, ok := labels_MAV_CMD[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/development/enum_param_transaction_action.go
+++ b/pkg/dialects/development/enum_param_transaction_action.go
@@ -3,7 +3,8 @@
 package development
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Possible parameter transaction actions.
@@ -26,27 +27,38 @@ var labels_PARAM_TRANSACTION_ACTION = map[PARAM_TRANSACTION_ACTION]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PARAM_TRANSACTION_ACTION) MarshalText() ([]byte, error) {
-	if l, ok := labels_PARAM_TRANSACTION_ACTION[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_PARAM_TRANSACTION_ACTION {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_PARAM_TRANSACTION_ACTION = map[string]PARAM_TRANSACTION_ACTION{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PARAM_TRANSACTION_ACTION) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_PARAM_TRANSACTION_ACTION[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask PARAM_TRANSACTION_ACTION
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_PARAM_TRANSACTION_ACTION {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PARAM_TRANSACTION_ACTION) String() string {
-	if l, ok := labels_PARAM_TRANSACTION_ACTION[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/development/enum_param_transaction_transport.go
+++ b/pkg/dialects/development/enum_param_transaction_transport.go
@@ -3,7 +3,8 @@
 package development
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Possible transport layers to set and get parameters via mavlink during a parameter transaction.
@@ -23,27 +24,38 @@ var labels_PARAM_TRANSACTION_TRANSPORT = map[PARAM_TRANSACTION_TRANSPORT]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PARAM_TRANSACTION_TRANSPORT) MarshalText() ([]byte, error) {
-	if l, ok := labels_PARAM_TRANSACTION_TRANSPORT[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_PARAM_TRANSACTION_TRANSPORT {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_PARAM_TRANSACTION_TRANSPORT = map[string]PARAM_TRANSACTION_TRANSPORT{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PARAM_TRANSACTION_TRANSPORT) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_PARAM_TRANSACTION_TRANSPORT[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask PARAM_TRANSACTION_TRANSPORT
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_PARAM_TRANSACTION_TRANSPORT {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PARAM_TRANSACTION_TRANSPORT) String() string {
-	if l, ok := labels_PARAM_TRANSACTION_TRANSPORT[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/development/enum_target_absolute_sensor_capability_flags.go
+++ b/pkg/dialects/development/enum_target_absolute_sensor_capability_flags.go
@@ -3,7 +3,8 @@
 package development
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // These flags indicate the sensor reporting capabilities for TARGET_ABSOLUTE.
@@ -27,27 +28,38 @@ var labels_TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS = map[TARGET_ABSOLUTE_SENSOR_
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS = map[string]TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS) String() string {
-	if l, ok := labels_TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/development/enum_wifi_network_security.go
+++ b/pkg/dialects/development/enum_wifi_network_security.go
@@ -3,7 +3,8 @@
 package development
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // WiFi wireless security protocols.
@@ -35,27 +36,38 @@ var labels_WIFI_NETWORK_SECURITY = map[WIFI_NETWORK_SECURITY]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e WIFI_NETWORK_SECURITY) MarshalText() ([]byte, error) {
-	if l, ok := labels_WIFI_NETWORK_SECURITY[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_WIFI_NETWORK_SECURITY {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_WIFI_NETWORK_SECURITY = map[string]WIFI_NETWORK_SECURITY{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *WIFI_NETWORK_SECURITY) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_WIFI_NETWORK_SECURITY[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask WIFI_NETWORK_SECURITY
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_WIFI_NETWORK_SECURITY {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e WIFI_NETWORK_SECURITY) String() string {
-	if l, ok := labels_WIFI_NETWORK_SECURITY[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/icarous/enum_icarous_fms_state.go
+++ b/pkg/dialects/icarous/enum_icarous_fms_state.go
@@ -3,7 +3,8 @@
 package icarous
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type ICAROUS_FMS_STATE uint32
@@ -28,27 +29,38 @@ var labels_ICAROUS_FMS_STATE = map[ICAROUS_FMS_STATE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ICAROUS_FMS_STATE) MarshalText() ([]byte, error) {
-	if l, ok := labels_ICAROUS_FMS_STATE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_ICAROUS_FMS_STATE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_ICAROUS_FMS_STATE = map[string]ICAROUS_FMS_STATE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ICAROUS_FMS_STATE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_ICAROUS_FMS_STATE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask ICAROUS_FMS_STATE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_ICAROUS_FMS_STATE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ICAROUS_FMS_STATE) String() string {
-	if l, ok := labels_ICAROUS_FMS_STATE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/icarous/enum_icarous_track_band_types.go
+++ b/pkg/dialects/icarous/enum_icarous_track_band_types.go
@@ -3,7 +3,8 @@
 package icarous
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type ICAROUS_TRACK_BAND_TYPES uint32
@@ -22,27 +23,38 @@ var labels_ICAROUS_TRACK_BAND_TYPES = map[ICAROUS_TRACK_BAND_TYPES]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ICAROUS_TRACK_BAND_TYPES) MarshalText() ([]byte, error) {
-	if l, ok := labels_ICAROUS_TRACK_BAND_TYPES[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_ICAROUS_TRACK_BAND_TYPES {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_ICAROUS_TRACK_BAND_TYPES = map[string]ICAROUS_TRACK_BAND_TYPES{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ICAROUS_TRACK_BAND_TYPES) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_ICAROUS_TRACK_BAND_TYPES[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask ICAROUS_TRACK_BAND_TYPES
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_ICAROUS_TRACK_BAND_TYPES {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ICAROUS_TRACK_BAND_TYPES) String() string {
-	if l, ok := labels_ICAROUS_TRACK_BAND_TYPES[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/matrixpilot/enum_mav_cmd.go
+++ b/pkg/dialects/matrixpilot/enum_mav_cmd.go
@@ -3,7 +3,8 @@
 package matrixpilot
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data. NaN and INT32_MAX may be used in float/integer params (respectively) to indicate optional/default values (e.g. to use the component's current yaw or latitude rather than a specific value). See https://mavlink.io/en/guide/xml_schema.html#MAV_CMD for information about the structure of the MAV_CMD entries
@@ -528,27 +529,38 @@ var labels_MAV_CMD = map[MAV_CMD]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_CMD[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_CMD {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_CMD = map[string]MAV_CMD{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_CMD[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_CMD
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_CMD {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD) String() string {
-	if l, ok := labels_MAV_CMD[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/matrixpilot/enum_mav_preflight_storage_action.go
+++ b/pkg/dialects/matrixpilot/enum_mav_preflight_storage_action.go
@@ -3,7 +3,8 @@
 package matrixpilot
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Action required when performing CMD_PREFLIGHT_STORAGE
@@ -38,27 +39,38 @@ var labels_MAV_PREFLIGHT_STORAGE_ACTION = map[MAV_PREFLIGHT_STORAGE_ACTION]strin
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_PREFLIGHT_STORAGE_ACTION) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_PREFLIGHT_STORAGE_ACTION[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_PREFLIGHT_STORAGE_ACTION {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_PREFLIGHT_STORAGE_ACTION = map[string]MAV_PREFLIGHT_STORAGE_ACTION{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_PREFLIGHT_STORAGE_ACTION) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_PREFLIGHT_STORAGE_ACTION[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_PREFLIGHT_STORAGE_ACTION
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_PREFLIGHT_STORAGE_ACTION {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_PREFLIGHT_STORAGE_ACTION) String() string {
-	if l, ok := labels_MAV_PREFLIGHT_STORAGE_ACTION[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/minimal/enum_mav_autopilot.go
+++ b/pkg/dialects/minimal/enum_mav_autopilot.go
@@ -3,7 +3,8 @@
 package minimal
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Micro air vehicle / autopilot classes. This identifies the individual model.
@@ -80,27 +81,38 @@ var labels_MAV_AUTOPILOT = map[MAV_AUTOPILOT]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_AUTOPILOT) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_AUTOPILOT[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_AUTOPILOT {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_AUTOPILOT = map[string]MAV_AUTOPILOT{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_AUTOPILOT) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_AUTOPILOT[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_AUTOPILOT
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_AUTOPILOT {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_AUTOPILOT) String() string {
-	if l, ok := labels_MAV_AUTOPILOT[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/minimal/enum_mav_component.go
+++ b/pkg/dialects/minimal/enum_mav_component.go
@@ -3,7 +3,8 @@
 package minimal
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Component ids (values) for the different types and instances of onboard hardware/software that might make up a MAVLink system (autopilot, cameras, servos, GPS systems, avoidance systems etc.).
@@ -424,27 +425,38 @@ var labels_MAV_COMPONENT = map[MAV_COMPONENT]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_COMPONENT) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_COMPONENT[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_COMPONENT {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_COMPONENT = map[string]MAV_COMPONENT{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_COMPONENT) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_COMPONENT[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_COMPONENT
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_COMPONENT {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_COMPONENT) String() string {
-	if l, ok := labels_MAV_COMPONENT[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/minimal/enum_mav_mode_flag.go
+++ b/pkg/dialects/minimal/enum_mav_mode_flag.go
@@ -3,7 +3,8 @@
 package minimal
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // These flags encode the MAV mode.
@@ -41,27 +42,38 @@ var labels_MAV_MODE_FLAG = map[MAV_MODE_FLAG]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MODE_FLAG) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_MODE_FLAG[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_MODE_FLAG {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_MODE_FLAG = map[string]MAV_MODE_FLAG{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_MODE_FLAG) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_MODE_FLAG[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_MODE_FLAG
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_MODE_FLAG {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_MODE_FLAG) String() string {
-	if l, ok := labels_MAV_MODE_FLAG[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/minimal/enum_mav_mode_flag_decode_position.go
+++ b/pkg/dialects/minimal/enum_mav_mode_flag_decode_position.go
@@ -3,7 +3,8 @@
 package minimal
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // These values encode the bit positions of the decode position. These values can be used to read the value of a flag bit by combining the base_mode variable with AND with the flag position value. The result will be either 0 or 1, depending on if the flag is set or not.
@@ -41,27 +42,38 @@ var labels_MAV_MODE_FLAG_DECODE_POSITION = map[MAV_MODE_FLAG_DECODE_POSITION]str
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MODE_FLAG_DECODE_POSITION) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_MODE_FLAG_DECODE_POSITION[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_MODE_FLAG_DECODE_POSITION {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_MODE_FLAG_DECODE_POSITION = map[string]MAV_MODE_FLAG_DECODE_POSITION{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_MODE_FLAG_DECODE_POSITION) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_MODE_FLAG_DECODE_POSITION[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_MODE_FLAG_DECODE_POSITION
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_MODE_FLAG_DECODE_POSITION {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_MODE_FLAG_DECODE_POSITION) String() string {
-	if l, ok := labels_MAV_MODE_FLAG_DECODE_POSITION[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/minimal/enum_mav_state.go
+++ b/pkg/dialects/minimal/enum_mav_state.go
@@ -3,7 +3,8 @@
 package minimal
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_STATE uint32
@@ -43,27 +44,38 @@ var labels_MAV_STATE = map[MAV_STATE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STATE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_STATE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_STATE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_STATE = map[string]MAV_STATE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_STATE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_STATE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_STATE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_STATE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_STATE) String() string {
-	if l, ok := labels_MAV_STATE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/minimal/enum_mav_type.go
+++ b/pkg/dialects/minimal/enum_mav_type.go
@@ -3,7 +3,8 @@
 package minimal
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // MAVLINK component type reported in HEARTBEAT message. Flight controllers must report the type of the vehicle on which they are mounted (e.g. MAV_TYPE_OCTOROTOR). All other components must report a value appropriate for their type (e.g. a camera must use MAV_TYPE_CAMERA).
@@ -146,27 +147,38 @@ var labels_MAV_TYPE = map[MAV_TYPE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_TYPE = map[string]MAV_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_TYPE) String() string {
-	if l, ok := labels_MAV_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/storm32/enum_mav_cmd.go
+++ b/pkg/dialects/storm32/enum_mav_cmd.go
@@ -3,7 +3,8 @@
 package storm32
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data. NaN and INT32_MAX may be used in float/integer params (respectively) to indicate optional/default values (e.g. to use the component's current yaw or latitude rather than a specific value). See https://mavlink.io/en/guide/xml_schema.html#MAV_CMD for information about the structure of the MAV_CMD entries
@@ -628,27 +629,38 @@ var labels_MAV_CMD = map[MAV_CMD]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_CMD[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_CMD {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_CMD = map[string]MAV_CMD{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_CMD[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_CMD
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_CMD {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD) String() string {
-	if l, ok := labels_MAV_CMD[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/storm32/enum_mav_qshot_mode.go
+++ b/pkg/dialects/storm32/enum_mav_qshot_mode.go
@@ -3,7 +3,8 @@
 package storm32
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Enumeration of possible shot modes.
@@ -47,27 +48,38 @@ var labels_MAV_QSHOT_MODE = map[MAV_QSHOT_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_QSHOT_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_QSHOT_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_QSHOT_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_QSHOT_MODE = map[string]MAV_QSHOT_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_QSHOT_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_QSHOT_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_QSHOT_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_QSHOT_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_QSHOT_MODE) String() string {
-	if l, ok := labels_MAV_QSHOT_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/storm32/enum_mav_storm32_camera_prearm_flags.go
+++ b/pkg/dialects/storm32/enum_mav_storm32_camera_prearm_flags.go
@@ -3,7 +3,8 @@
 package storm32
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // STorM32 camera prearm check flags.
@@ -20,27 +21,38 @@ var labels_MAV_STORM32_CAMERA_PREARM_FLAGS = map[MAV_STORM32_CAMERA_PREARM_FLAGS
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STORM32_CAMERA_PREARM_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_STORM32_CAMERA_PREARM_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_STORM32_CAMERA_PREARM_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_STORM32_CAMERA_PREARM_FLAGS = map[string]MAV_STORM32_CAMERA_PREARM_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_STORM32_CAMERA_PREARM_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_STORM32_CAMERA_PREARM_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_STORM32_CAMERA_PREARM_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_STORM32_CAMERA_PREARM_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_STORM32_CAMERA_PREARM_FLAGS) String() string {
-	if l, ok := labels_MAV_STORM32_CAMERA_PREARM_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_cap_flags.go
+++ b/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_cap_flags.go
@@ -3,7 +3,8 @@
 package storm32
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Gimbal manager capability flags.
@@ -20,27 +21,38 @@ var labels_MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS = map[MAV_STORM32_GIMBAL_MANAGER
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS = map[string]MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS) String() string {
-	if l, ok := labels_MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_client.go
+++ b/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_client.go
@@ -3,7 +3,8 @@
 package storm32
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Gimbal manager client ID. In a prioritizing profile, the priorities are determined by the implementation; they could e.g. be custom1 > onboard > GCS > autopilot/camera > GCS2 > custom2.
@@ -44,27 +45,38 @@ var labels_MAV_STORM32_GIMBAL_MANAGER_CLIENT = map[MAV_STORM32_GIMBAL_MANAGER_CL
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STORM32_GIMBAL_MANAGER_CLIENT) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_STORM32_GIMBAL_MANAGER_CLIENT[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_STORM32_GIMBAL_MANAGER_CLIENT {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_STORM32_GIMBAL_MANAGER_CLIENT = map[string]MAV_STORM32_GIMBAL_MANAGER_CLIENT{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_STORM32_GIMBAL_MANAGER_CLIENT) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_STORM32_GIMBAL_MANAGER_CLIENT[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_STORM32_GIMBAL_MANAGER_CLIENT
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_STORM32_GIMBAL_MANAGER_CLIENT {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_STORM32_GIMBAL_MANAGER_CLIENT) String() string {
-	if l, ok := labels_MAV_STORM32_GIMBAL_MANAGER_CLIENT[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_flags.go
+++ b/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_flags.go
@@ -3,7 +3,8 @@
 package storm32
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Flags for gimbal manager operation. Used for setting and reporting, unless specified otherwise. If a setting has been accepted by the gimbal manager is reported in the STORM32_GIMBAL_MANAGER_STATUS message.
@@ -53,27 +54,38 @@ var labels_MAV_STORM32_GIMBAL_MANAGER_FLAGS = map[MAV_STORM32_GIMBAL_MANAGER_FLA
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STORM32_GIMBAL_MANAGER_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_STORM32_GIMBAL_MANAGER_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_STORM32_GIMBAL_MANAGER_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_STORM32_GIMBAL_MANAGER_FLAGS = map[string]MAV_STORM32_GIMBAL_MANAGER_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_STORM32_GIMBAL_MANAGER_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_STORM32_GIMBAL_MANAGER_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_STORM32_GIMBAL_MANAGER_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_STORM32_GIMBAL_MANAGER_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_STORM32_GIMBAL_MANAGER_FLAGS) String() string {
-	if l, ok := labels_MAV_STORM32_GIMBAL_MANAGER_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_profile.go
+++ b/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_profile.go
@@ -3,7 +3,8 @@
 package storm32
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Gimbal manager profiles. Only standard profiles are defined. Any implementation can define its own profile(s) in addition, and should use enum values > 16.
@@ -35,27 +36,38 @@ var labels_MAV_STORM32_GIMBAL_MANAGER_PROFILE = map[MAV_STORM32_GIMBAL_MANAGER_P
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STORM32_GIMBAL_MANAGER_PROFILE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_STORM32_GIMBAL_MANAGER_PROFILE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_STORM32_GIMBAL_MANAGER_PROFILE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_STORM32_GIMBAL_MANAGER_PROFILE = map[string]MAV_STORM32_GIMBAL_MANAGER_PROFILE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_STORM32_GIMBAL_MANAGER_PROFILE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_STORM32_GIMBAL_MANAGER_PROFILE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_STORM32_GIMBAL_MANAGER_PROFILE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_STORM32_GIMBAL_MANAGER_PROFILE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_STORM32_GIMBAL_MANAGER_PROFILE) String() string {
-	if l, ok := labels_MAV_STORM32_GIMBAL_MANAGER_PROFILE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/storm32/enum_mav_storm32_gimbal_prearm_flags.go
+++ b/pkg/dialects/storm32/enum_mav_storm32_gimbal_prearm_flags.go
@@ -3,7 +3,8 @@
 package storm32
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // STorM32 gimbal prearm check flags.
@@ -56,27 +57,38 @@ var labels_MAV_STORM32_GIMBAL_PREARM_FLAGS = map[MAV_STORM32_GIMBAL_PREARM_FLAGS
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STORM32_GIMBAL_PREARM_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_STORM32_GIMBAL_PREARM_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_STORM32_GIMBAL_PREARM_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_STORM32_GIMBAL_PREARM_FLAGS = map[string]MAV_STORM32_GIMBAL_PREARM_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_STORM32_GIMBAL_PREARM_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_STORM32_GIMBAL_PREARM_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_STORM32_GIMBAL_PREARM_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_STORM32_GIMBAL_PREARM_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_STORM32_GIMBAL_PREARM_FLAGS) String() string {
-	if l, ok := labels_MAV_STORM32_GIMBAL_PREARM_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/storm32/enum_mav_storm32_tunnel_payload_type.go
+++ b/pkg/dialects/storm32/enum_mav_storm32_tunnel_payload_type.go
@@ -3,7 +3,8 @@
 package storm32
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 type MAV_STORM32_TUNNEL_PAYLOAD_TYPE uint32
@@ -34,27 +35,38 @@ var labels_MAV_STORM32_TUNNEL_PAYLOAD_TYPE = map[MAV_STORM32_TUNNEL_PAYLOAD_TYPE
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STORM32_TUNNEL_PAYLOAD_TYPE) MarshalText() ([]byte, error) {
-	if l, ok := labels_MAV_STORM32_TUNNEL_PAYLOAD_TYPE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_MAV_STORM32_TUNNEL_PAYLOAD_TYPE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_MAV_STORM32_TUNNEL_PAYLOAD_TYPE = map[string]MAV_STORM32_TUNNEL_PAYLOAD_TYPE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_STORM32_TUNNEL_PAYLOAD_TYPE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_MAV_STORM32_TUNNEL_PAYLOAD_TYPE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask MAV_STORM32_TUNNEL_PAYLOAD_TYPE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_MAV_STORM32_TUNNEL_PAYLOAD_TYPE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_STORM32_TUNNEL_PAYLOAD_TYPE) String() string {
-	if l, ok := labels_MAV_STORM32_TUNNEL_PAYLOAD_TYPE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/storm32/enum_radio_link_stats_flags.go
+++ b/pkg/dialects/storm32/enum_radio_link_stats_flags.go
@@ -3,7 +3,8 @@
 package storm32
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // RADIO_LINK_STATS flags (bitmask).
@@ -20,27 +21,38 @@ var labels_RADIO_LINK_STATS_FLAGS = map[RADIO_LINK_STATS_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e RADIO_LINK_STATS_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_RADIO_LINK_STATS_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_RADIO_LINK_STATS_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_RADIO_LINK_STATS_FLAGS = map[string]RADIO_LINK_STATS_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *RADIO_LINK_STATS_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_RADIO_LINK_STATS_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask RADIO_LINK_STATS_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_RADIO_LINK_STATS_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e RADIO_LINK_STATS_FLAGS) String() string {
-	if l, ok := labels_RADIO_LINK_STATS_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/storm32/enum_radio_rc_channels_flags.go
+++ b/pkg/dialects/storm32/enum_radio_rc_channels_flags.go
@@ -3,7 +3,8 @@
 package storm32
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // RADIO_RC_CHANNELS flags (bitmask).
@@ -23,27 +24,38 @@ var labels_RADIO_RC_CHANNELS_FLAGS = map[RADIO_RC_CHANNELS_FLAGS]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e RADIO_RC_CHANNELS_FLAGS) MarshalText() ([]byte, error) {
-	if l, ok := labels_RADIO_RC_CHANNELS_FLAGS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_RADIO_RC_CHANNELS_FLAGS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_RADIO_RC_CHANNELS_FLAGS = map[string]RADIO_RC_CHANNELS_FLAGS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *RADIO_RC_CHANNELS_FLAGS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_RADIO_RC_CHANNELS_FLAGS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask RADIO_RC_CHANNELS_FLAGS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_RADIO_RC_CHANNELS_FLAGS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e RADIO_RC_CHANNELS_FLAGS) String() string {
-	if l, ok := labels_RADIO_RC_CHANNELS_FLAGS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ualberta/enum_ualberta_autopilot_mode.go
+++ b/pkg/dialects/ualberta/enum_ualberta_autopilot_mode.go
@@ -3,7 +3,8 @@
 package ualberta
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Available autopilot modes for ualberta uav
@@ -29,27 +30,38 @@ var labels_UALBERTA_AUTOPILOT_MODE = map[UALBERTA_AUTOPILOT_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UALBERTA_AUTOPILOT_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_UALBERTA_AUTOPILOT_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_UALBERTA_AUTOPILOT_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_UALBERTA_AUTOPILOT_MODE = map[string]UALBERTA_AUTOPILOT_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UALBERTA_AUTOPILOT_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_UALBERTA_AUTOPILOT_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask UALBERTA_AUTOPILOT_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_UALBERTA_AUTOPILOT_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UALBERTA_AUTOPILOT_MODE) String() string {
-	if l, ok := labels_UALBERTA_AUTOPILOT_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ualberta/enum_ualberta_nav_mode.go
+++ b/pkg/dialects/ualberta/enum_ualberta_nav_mode.go
@@ -3,7 +3,8 @@
 package ualberta
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Navigation filter mode
@@ -28,27 +29,38 @@ var labels_UALBERTA_NAV_MODE = map[UALBERTA_NAV_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UALBERTA_NAV_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_UALBERTA_NAV_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_UALBERTA_NAV_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_UALBERTA_NAV_MODE = map[string]UALBERTA_NAV_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UALBERTA_NAV_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_UALBERTA_NAV_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask UALBERTA_NAV_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_UALBERTA_NAV_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UALBERTA_NAV_MODE) String() string {
-	if l, ok := labels_UALBERTA_NAV_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/ualberta/enum_ualberta_pilot_mode.go
+++ b/pkg/dialects/ualberta/enum_ualberta_pilot_mode.go
@@ -3,7 +3,8 @@
 package ualberta
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Mode currently commanded by pilot
@@ -24,27 +25,38 @@ var labels_UALBERTA_PILOT_MODE = map[UALBERTA_PILOT_MODE]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UALBERTA_PILOT_MODE) MarshalText() ([]byte, error) {
-	if l, ok := labels_UALBERTA_PILOT_MODE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_UALBERTA_PILOT_MODE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_UALBERTA_PILOT_MODE = map[string]UALBERTA_PILOT_MODE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UALBERTA_PILOT_MODE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_UALBERTA_PILOT_MODE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask UALBERTA_PILOT_MODE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_UALBERTA_PILOT_MODE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UALBERTA_PILOT_MODE) String() string {
-	if l, ok := labels_UALBERTA_PILOT_MODE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_emergency_status.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_emergency_status.go
@@ -3,7 +3,8 @@
 package uavionix
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Emergency status encoding
@@ -33,27 +34,38 @@ var labels_UAVIONIX_ADSB_EMERGENCY_STATUS = map[UAVIONIX_ADSB_EMERGENCY_STATUS]s
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_EMERGENCY_STATUS) MarshalText() ([]byte, error) {
-	if l, ok := labels_UAVIONIX_ADSB_EMERGENCY_STATUS[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_UAVIONIX_ADSB_EMERGENCY_STATUS {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_UAVIONIX_ADSB_EMERGENCY_STATUS = map[string]UAVIONIX_ADSB_EMERGENCY_STATUS{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVIONIX_ADSB_EMERGENCY_STATUS) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_UAVIONIX_ADSB_EMERGENCY_STATUS[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask UAVIONIX_ADSB_EMERGENCY_STATUS
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_UAVIONIX_ADSB_EMERGENCY_STATUS {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVIONIX_ADSB_EMERGENCY_STATUS) String() string {
-	if l, ok := labels_UAVIONIX_ADSB_EMERGENCY_STATUS[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_out_cfg_aircraft_size.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_out_cfg_aircraft_size.go
@@ -3,7 +3,8 @@
 package uavionix
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Definitions for aircraft size
@@ -49,27 +50,38 @@ var labels_UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE = map[UAVIONIX_ADSB_OUT_CFG_AIRCR
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE) MarshalText() ([]byte, error) {
-	if l, ok := labels_UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE = map[string]UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE) String() string {
-	if l, ok := labels_UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_out_cfg_gps_offset_lat.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_out_cfg_gps_offset_lat.go
@@ -3,7 +3,8 @@
 package uavionix
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // GPS lataral offset encoding
@@ -33,27 +34,38 @@ var labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT = map[UAVIONIX_ADSB_OUT_CFG_GPS_
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT) MarshalText() ([]byte, error) {
-	if l, ok := labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT = map[string]UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT) String() string {
-	if l, ok := labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_out_cfg_gps_offset_lon.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_out_cfg_gps_offset_lon.go
@@ -3,7 +3,8 @@
 package uavionix
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // GPS longitudinal offset encoding
@@ -21,27 +22,38 @@ var labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON = map[UAVIONIX_ADSB_OUT_CFG_GPS_
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON) MarshalText() ([]byte, error) {
-	if l, ok := labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON = map[string]UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON) String() string {
-	if l, ok := labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_out_dynamic_gps_fix.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_out_dynamic_gps_fix.go
@@ -3,7 +3,8 @@
 package uavionix
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Status for ADS-B transponder dynamic input
@@ -29,27 +30,38 @@ var labels_UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX = map[UAVIONIX_ADSB_OUT_DYNAMIC_GPS
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX) MarshalText() ([]byte, error) {
-	if l, ok := labels_UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX = map[string]UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX) String() string {
-	if l, ok := labels_UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_out_dynamic_state.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_out_dynamic_state.go
@@ -3,7 +3,8 @@
 package uavionix
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // State flags for ADS-B transponder dynamic report
@@ -27,27 +28,38 @@ var labels_UAVIONIX_ADSB_OUT_DYNAMIC_STATE = map[UAVIONIX_ADSB_OUT_DYNAMIC_STATE
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_OUT_DYNAMIC_STATE) MarshalText() ([]byte, error) {
-	if l, ok := labels_UAVIONIX_ADSB_OUT_DYNAMIC_STATE[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_UAVIONIX_ADSB_OUT_DYNAMIC_STATE {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_UAVIONIX_ADSB_OUT_DYNAMIC_STATE = map[string]UAVIONIX_ADSB_OUT_DYNAMIC_STATE{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVIONIX_ADSB_OUT_DYNAMIC_STATE) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_UAVIONIX_ADSB_OUT_DYNAMIC_STATE[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask UAVIONIX_ADSB_OUT_DYNAMIC_STATE
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_UAVIONIX_ADSB_OUT_DYNAMIC_STATE {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVIONIX_ADSB_OUT_DYNAMIC_STATE) String() string {
-	if l, ok := labels_UAVIONIX_ADSB_OUT_DYNAMIC_STATE[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_out_rf_select.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_out_rf_select.go
@@ -3,7 +3,8 @@
 package uavionix
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Transceiver RF control flags for ADS-B transponder dynamic reports
@@ -23,27 +24,38 @@ var labels_UAVIONIX_ADSB_OUT_RF_SELECT = map[UAVIONIX_ADSB_OUT_RF_SELECT]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_OUT_RF_SELECT) MarshalText() ([]byte, error) {
-	if l, ok := labels_UAVIONIX_ADSB_OUT_RF_SELECT[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_UAVIONIX_ADSB_OUT_RF_SELECT {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_UAVIONIX_ADSB_OUT_RF_SELECT = map[string]UAVIONIX_ADSB_OUT_RF_SELECT{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVIONIX_ADSB_OUT_RF_SELECT) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_UAVIONIX_ADSB_OUT_RF_SELECT[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask UAVIONIX_ADSB_OUT_RF_SELECT
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_UAVIONIX_ADSB_OUT_RF_SELECT {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVIONIX_ADSB_OUT_RF_SELECT) String() string {
-	if l, ok := labels_UAVIONIX_ADSB_OUT_RF_SELECT[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_rf_health.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_rf_health.go
@@ -3,7 +3,8 @@
 package uavionix
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 )
 
 // Status flags for ADS-B transponder dynamic output
@@ -25,27 +26,38 @@ var labels_UAVIONIX_ADSB_RF_HEALTH = map[UAVIONIX_ADSB_RF_HEALTH]string{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_RF_HEALTH) MarshalText() ([]byte, error) {
-	if l, ok := labels_UAVIONIX_ADSB_RF_HEALTH[e]; ok {
-		return []byte(l), nil
+	var names []string
+	for mask, label := range labels_UAVIONIX_ADSB_RF_HEALTH {
+		if e&mask == mask {
+			names = append(names, label)
+		}
 	}
-	return nil, errors.New("invalid value")
+	return []byte(strings.Join(names, " | ")), nil
 }
-
-var reverseLabels_UAVIONIX_ADSB_RF_HEALTH = map[string]UAVIONIX_ADSB_RF_HEALTH{}
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVIONIX_ADSB_RF_HEALTH) UnmarshalText(text []byte) error {
-	if rl, ok := reverseLabels_UAVIONIX_ADSB_RF_HEALTH[string(text)]; ok {
-		*e = rl
-		return nil
+	labels := strings.Split(string(text), " | ")
+	var mask UAVIONIX_ADSB_RF_HEALTH
+	for _, label := range labels {
+		found := false
+		for value, l := range labels_UAVIONIX_ADSB_RF_HEALTH {
+			if l == label {
+				mask |= value
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid label '%s'", label)
+		}
 	}
-	return errors.New("invalid value")
+	*e = mask
+	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVIONIX_ADSB_RF_HEALTH) String() string {
-	if l, ok := labels_UAVIONIX_ADSB_RF_HEALTH[e]; ok {
-		return l
-	}
-	return "invalid value"
+	val, _ := e.MarshalText()
+	return string(val)
 }


### PR DESCRIPTION
Bug while calling the `MarshalText` method for enum 
Example:
`(common.MAV_SYS_STATUS_SENSOR_3D_GYRO | common.MAV_SYS_STATUS_SENSOR_3D_ACCEL).MarshalText()`

an error occurs because this value is not in labels_{{ENUM}}

I propose to return the hex value of the number.