### PR TITLE
add serial to json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Features:
   * [events](examples/events/main.go)
   * [router](examples/router/main.go)
   * [router-edit](examples/router-edit/main.go)
+  * [serial-to-json](examples/serial-to-json/main.go)
   * [stream-requests](examples/stream-requests/main.go)
   * [readwriter](examples/readwriter/main.go)
 

--- a/examples/serial-to-json/main.go
+++ b/examples/serial-to-json/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/bluenviron/gomavlib/v2"
+	"github.com/bluenviron/gomavlib/v2/pkg/dialects/common"
+	"github.com/bluenviron/gomavlib/v2/pkg/frame"
+)
+
+// this example shows how to:
+// 1) create a node which communicates with a serial endpoint
+// 2) convert any message to a generic JSON object
+// the output of this example can be combined with a JSON parser like jq to display individual messages, for example:
+//     go run ./examples/serial-to-json | jq 'select(.MessageType == "*minimal.MessageHeartbeat")'
+
+func main() {
+	baudRate := flag.Int("b", 57600, "baud rate")
+	port := flag.String("p", "/dev/ttyUSB0", "port")
+	flag.Parse()
+
+	// create a node which communicates with a serial endpoint
+	node, err := gomavlib.NewNode(gomavlib.NodeConf{
+		Endpoints: []gomavlib.EndpointConf{
+			gomavlib.EndpointSerial{
+				Device: *port,
+				Baud:   *baudRate,
+			},
+		},
+		Dialect:     common.Dialect,
+		OutVersion:  gomavlib.V2, // change to V1 if you're unable to communicate with the target
+		OutSystemID: 10,
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer node.Close()
+
+	jsonEncoder := json.NewEncoder(os.Stdout)
+	for evt := range node.Events() {
+		if frm, ok := evt.(*gomavlib.EventFrame); ok {
+			// add the message type to the JSON object
+			if err := jsonEncoder.Encode(struct {
+				MessageType string
+				Frame       *frame.Frame
+			}{
+				MessageType: fmt.Sprintf("%T", frm.Message()),
+				Frame:       &frm.Frame,
+			}); err != nil {
+				// some messages contain floating point NaN values which cannot be encoded in JSON
+				// silently ignore these errors
+				if err.Error() != "json: unsupported value: NaN" {
+					panic(err)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This example is very similar to the [existing `stream-requests` example](https://github.com/bluenviron/gomavlib/tree/4ff9532aa0e91077b4ce64b17d06dc716c55a156/examples/stream-requests), but emits JSON instead of log messages.

This example is particularly useful as a monitor when combined with a JSON tool like [jq](https://jqlang.github.io/jq/). For example, to display only heartbeat messages you can do:

```console
$ go run ./examples/serial-to-json | jq 'select(.MessageType == "*minimal.MessageHeartbeat")
```