### PR TITLE
fix conversion of bitmasks to strings

### DIFF
--- a/pkg/conversion/definition.go
+++ b/pkg/conversion/definition.go
@@ -15,6 +15,7 @@ type definitionEnum struct {
 	Name        string                 `xml:"name,attr"`
 	Description string                 `xml:"description"`
 	Values      []*definitionEnumValue `xml:"entry"`
+	Bitmask     bool                   `xml:"bitmask,attr"`
 }
 
 type dialectField struct {

--- a/pkg/dialects/minimal/enum_mav_autopilot.go
+++ b/pkg/dialects/minimal/enum_mav_autopilot.go
@@ -4,7 +4,7 @@ package minimal
 
 import (
 	"fmt"
-	"strings"
+	"strconv"
 )
 
 // Micro air vehicle / autopilot classes. This identifies the individual model.
@@ -79,40 +79,54 @@ var labels_MAV_AUTOPILOT = map[MAV_AUTOPILOT]string{
 	MAV_AUTOPILOT_REFLEX:                                       "MAV_AUTOPILOT_REFLEX",
 }
 
+var values_MAV_AUTOPILOT = map[string]MAV_AUTOPILOT{
+	"MAV_AUTOPILOT_GENERIC":                                      MAV_AUTOPILOT_GENERIC,
+	"MAV_AUTOPILOT_RESERVED":                                     MAV_AUTOPILOT_RESERVED,
+	"MAV_AUTOPILOT_SLUGS":                                        MAV_AUTOPILOT_SLUGS,
+	"MAV_AUTOPILOT_ARDUPILOTMEGA":                                MAV_AUTOPILOT_ARDUPILOTMEGA,
+	"MAV_AUTOPILOT_OPENPILOT":                                    MAV_AUTOPILOT_OPENPILOT,
+	"MAV_AUTOPILOT_GENERIC_WAYPOINTS_ONLY":                       MAV_AUTOPILOT_GENERIC_WAYPOINTS_ONLY,
+	"MAV_AUTOPILOT_GENERIC_WAYPOINTS_AND_SIMPLE_NAVIGATION_ONLY": MAV_AUTOPILOT_GENERIC_WAYPOINTS_AND_SIMPLE_NAVIGATION_ONLY,
+	"MAV_AUTOPILOT_GENERIC_MISSION_FULL":                         MAV_AUTOPILOT_GENERIC_MISSION_FULL,
+	"MAV_AUTOPILOT_INVALID":                                      MAV_AUTOPILOT_INVALID,
+	"MAV_AUTOPILOT_PPZ":                                          MAV_AUTOPILOT_PPZ,
+	"MAV_AUTOPILOT_UDB":                                          MAV_AUTOPILOT_UDB,
+	"MAV_AUTOPILOT_FP":                                           MAV_AUTOPILOT_FP,
+	"MAV_AUTOPILOT_PX4":                                          MAV_AUTOPILOT_PX4,
+	"MAV_AUTOPILOT_SMACCMPILOT":                                  MAV_AUTOPILOT_SMACCMPILOT,
+	"MAV_AUTOPILOT_AUTOQUAD":                                     MAV_AUTOPILOT_AUTOQUAD,
+	"MAV_AUTOPILOT_ARMAZILA":                                     MAV_AUTOPILOT_ARMAZILA,
+	"MAV_AUTOPILOT_AEROB":                                        MAV_AUTOPILOT_AEROB,
+	"MAV_AUTOPILOT_ASLUAV":                                       MAV_AUTOPILOT_ASLUAV,
+	"MAV_AUTOPILOT_SMARTAP":                                      MAV_AUTOPILOT_SMARTAP,
+	"MAV_AUTOPILOT_AIRRAILS":                                     MAV_AUTOPILOT_AIRRAILS,
+	"MAV_AUTOPILOT_REFLEX":                                       MAV_AUTOPILOT_REFLEX,
+}
+
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_AUTOPILOT) MarshalText() ([]byte, error) {
-	var names []string
-	for mask, label := range labels_MAV_AUTOPILOT {
-		if e&mask == mask {
-			names = append(names, label)
-		}
+	name, ok := labels_MAV_AUTOPILOT[e]
+	if !ok {
+		return nil, fmt.Errorf("invalid value %d", e)
 	}
-	return []byte(strings.Join(names, " | ")), nil
+	return []byte(name), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_AUTOPILOT) UnmarshalText(text []byte) error {
-	labels := strings.Split(string(text), " | ")
-	var mask MAV_AUTOPILOT
-	for _, label := range labels {
-		found := false
-		for value, l := range labels_MAV_AUTOPILOT {
-			if l == label {
-				mask |= value
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("invalid label '%s'", label)
-		}
+	value, ok := values_MAV_AUTOPILOT[string(text)]
+	if !ok {
+		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = mask
+	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_AUTOPILOT) String() string {
-	val, _ := e.MarshalText()
-	return string(val)
+	name, ok := labels_MAV_AUTOPILOT[e]
+	if !ok {
+		return strconv.Itoa(int(e))
+	}
+	return name
 }

--- a/pkg/dialects/minimal/enum_mav_component.go
+++ b/pkg/dialects/minimal/enum_mav_component.go
@@ -4,7 +4,7 @@ package minimal
 
 import (
 	"fmt"
-	"strings"
+	"strconv"
 )
 
 // Component ids (values) for the different types and instances of onboard hardware/software that might make up a MAVLink system (autopilot, cameras, servos, GPS systems, avoidance systems etc.).
@@ -423,40 +423,168 @@ var labels_MAV_COMPONENT = map[MAV_COMPONENT]string{
 	MAV_COMP_ID_SYSTEM_CONTROL:           "MAV_COMP_ID_SYSTEM_CONTROL",
 }
 
+var values_MAV_COMPONENT = map[string]MAV_COMPONENT{
+	"MAV_COMP_ID_ALL":                      MAV_COMP_ID_ALL,
+	"MAV_COMP_ID_AUTOPILOT1":               MAV_COMP_ID_AUTOPILOT1,
+	"MAV_COMP_ID_USER1":                    MAV_COMP_ID_USER1,
+	"MAV_COMP_ID_USER2":                    MAV_COMP_ID_USER2,
+	"MAV_COMP_ID_USER3":                    MAV_COMP_ID_USER3,
+	"MAV_COMP_ID_USER4":                    MAV_COMP_ID_USER4,
+	"MAV_COMP_ID_USER5":                    MAV_COMP_ID_USER5,
+	"MAV_COMP_ID_USER6":                    MAV_COMP_ID_USER6,
+	"MAV_COMP_ID_USER7":                    MAV_COMP_ID_USER7,
+	"MAV_COMP_ID_USER8":                    MAV_COMP_ID_USER8,
+	"MAV_COMP_ID_USER9":                    MAV_COMP_ID_USER9,
+	"MAV_COMP_ID_USER10":                   MAV_COMP_ID_USER10,
+	"MAV_COMP_ID_USER11":                   MAV_COMP_ID_USER11,
+	"MAV_COMP_ID_USER12":                   MAV_COMP_ID_USER12,
+	"MAV_COMP_ID_USER13":                   MAV_COMP_ID_USER13,
+	"MAV_COMP_ID_USER14":                   MAV_COMP_ID_USER14,
+	"MAV_COMP_ID_USER15":                   MAV_COMP_ID_USER15,
+	"MAV_COMP_ID_USER16":                   MAV_COMP_ID_USER16,
+	"MAV_COMP_ID_USER17":                   MAV_COMP_ID_USER17,
+	"MAV_COMP_ID_USER18":                   MAV_COMP_ID_USER18,
+	"MAV_COMP_ID_USER19":                   MAV_COMP_ID_USER19,
+	"MAV_COMP_ID_USER20":                   MAV_COMP_ID_USER20,
+	"MAV_COMP_ID_USER21":                   MAV_COMP_ID_USER21,
+	"MAV_COMP_ID_USER22":                   MAV_COMP_ID_USER22,
+	"MAV_COMP_ID_USER23":                   MAV_COMP_ID_USER23,
+	"MAV_COMP_ID_USER24":                   MAV_COMP_ID_USER24,
+	"MAV_COMP_ID_USER25":                   MAV_COMP_ID_USER25,
+	"MAV_COMP_ID_USER26":                   MAV_COMP_ID_USER26,
+	"MAV_COMP_ID_USER27":                   MAV_COMP_ID_USER27,
+	"MAV_COMP_ID_USER28":                   MAV_COMP_ID_USER28,
+	"MAV_COMP_ID_USER29":                   MAV_COMP_ID_USER29,
+	"MAV_COMP_ID_USER30":                   MAV_COMP_ID_USER30,
+	"MAV_COMP_ID_USER31":                   MAV_COMP_ID_USER31,
+	"MAV_COMP_ID_USER32":                   MAV_COMP_ID_USER32,
+	"MAV_COMP_ID_USER33":                   MAV_COMP_ID_USER33,
+	"MAV_COMP_ID_USER34":                   MAV_COMP_ID_USER34,
+	"MAV_COMP_ID_USER35":                   MAV_COMP_ID_USER35,
+	"MAV_COMP_ID_USER36":                   MAV_COMP_ID_USER36,
+	"MAV_COMP_ID_USER37":                   MAV_COMP_ID_USER37,
+	"MAV_COMP_ID_USER38":                   MAV_COMP_ID_USER38,
+	"MAV_COMP_ID_USER39":                   MAV_COMP_ID_USER39,
+	"MAV_COMP_ID_USER40":                   MAV_COMP_ID_USER40,
+	"MAV_COMP_ID_USER41":                   MAV_COMP_ID_USER41,
+	"MAV_COMP_ID_USER42":                   MAV_COMP_ID_USER42,
+	"MAV_COMP_ID_USER43":                   MAV_COMP_ID_USER43,
+	"MAV_COMP_ID_TELEMETRY_RADIO":          MAV_COMP_ID_TELEMETRY_RADIO,
+	"MAV_COMP_ID_USER45":                   MAV_COMP_ID_USER45,
+	"MAV_COMP_ID_USER46":                   MAV_COMP_ID_USER46,
+	"MAV_COMP_ID_USER47":                   MAV_COMP_ID_USER47,
+	"MAV_COMP_ID_USER48":                   MAV_COMP_ID_USER48,
+	"MAV_COMP_ID_USER49":                   MAV_COMP_ID_USER49,
+	"MAV_COMP_ID_USER50":                   MAV_COMP_ID_USER50,
+	"MAV_COMP_ID_USER51":                   MAV_COMP_ID_USER51,
+	"MAV_COMP_ID_USER52":                   MAV_COMP_ID_USER52,
+	"MAV_COMP_ID_USER53":                   MAV_COMP_ID_USER53,
+	"MAV_COMP_ID_USER54":                   MAV_COMP_ID_USER54,
+	"MAV_COMP_ID_USER55":                   MAV_COMP_ID_USER55,
+	"MAV_COMP_ID_USER56":                   MAV_COMP_ID_USER56,
+	"MAV_COMP_ID_USER57":                   MAV_COMP_ID_USER57,
+	"MAV_COMP_ID_USER58":                   MAV_COMP_ID_USER58,
+	"MAV_COMP_ID_USER59":                   MAV_COMP_ID_USER59,
+	"MAV_COMP_ID_USER60":                   MAV_COMP_ID_USER60,
+	"MAV_COMP_ID_USER61":                   MAV_COMP_ID_USER61,
+	"MAV_COMP_ID_USER62":                   MAV_COMP_ID_USER62,
+	"MAV_COMP_ID_USER63":                   MAV_COMP_ID_USER63,
+	"MAV_COMP_ID_USER64":                   MAV_COMP_ID_USER64,
+	"MAV_COMP_ID_USER65":                   MAV_COMP_ID_USER65,
+	"MAV_COMP_ID_USER66":                   MAV_COMP_ID_USER66,
+	"MAV_COMP_ID_USER67":                   MAV_COMP_ID_USER67,
+	"MAV_COMP_ID_USER68":                   MAV_COMP_ID_USER68,
+	"MAV_COMP_ID_USER69":                   MAV_COMP_ID_USER69,
+	"MAV_COMP_ID_USER70":                   MAV_COMP_ID_USER70,
+	"MAV_COMP_ID_USER71":                   MAV_COMP_ID_USER71,
+	"MAV_COMP_ID_USER72":                   MAV_COMP_ID_USER72,
+	"MAV_COMP_ID_USER73":                   MAV_COMP_ID_USER73,
+	"MAV_COMP_ID_USER74":                   MAV_COMP_ID_USER74,
+	"MAV_COMP_ID_USER75":                   MAV_COMP_ID_USER75,
+	"MAV_COMP_ID_CAMERA":                   MAV_COMP_ID_CAMERA,
+	"MAV_COMP_ID_CAMERA2":                  MAV_COMP_ID_CAMERA2,
+	"MAV_COMP_ID_CAMERA3":                  MAV_COMP_ID_CAMERA3,
+	"MAV_COMP_ID_CAMERA4":                  MAV_COMP_ID_CAMERA4,
+	"MAV_COMP_ID_CAMERA5":                  MAV_COMP_ID_CAMERA5,
+	"MAV_COMP_ID_CAMERA6":                  MAV_COMP_ID_CAMERA6,
+	"MAV_COMP_ID_SERVO1":                   MAV_COMP_ID_SERVO1,
+	"MAV_COMP_ID_SERVO2":                   MAV_COMP_ID_SERVO2,
+	"MAV_COMP_ID_SERVO3":                   MAV_COMP_ID_SERVO3,
+	"MAV_COMP_ID_SERVO4":                   MAV_COMP_ID_SERVO4,
+	"MAV_COMP_ID_SERVO5":                   MAV_COMP_ID_SERVO5,
+	"MAV_COMP_ID_SERVO6":                   MAV_COMP_ID_SERVO6,
+	"MAV_COMP_ID_SERVO7":                   MAV_COMP_ID_SERVO7,
+	"MAV_COMP_ID_SERVO8":                   MAV_COMP_ID_SERVO8,
+	"MAV_COMP_ID_SERVO9":                   MAV_COMP_ID_SERVO9,
+	"MAV_COMP_ID_SERVO10":                  MAV_COMP_ID_SERVO10,
+	"MAV_COMP_ID_SERVO11":                  MAV_COMP_ID_SERVO11,
+	"MAV_COMP_ID_SERVO12":                  MAV_COMP_ID_SERVO12,
+	"MAV_COMP_ID_SERVO13":                  MAV_COMP_ID_SERVO13,
+	"MAV_COMP_ID_SERVO14":                  MAV_COMP_ID_SERVO14,
+	"MAV_COMP_ID_GIMBAL":                   MAV_COMP_ID_GIMBAL,
+	"MAV_COMP_ID_LOG":                      MAV_COMP_ID_LOG,
+	"MAV_COMP_ID_ADSB":                     MAV_COMP_ID_ADSB,
+	"MAV_COMP_ID_OSD":                      MAV_COMP_ID_OSD,
+	"MAV_COMP_ID_PERIPHERAL":               MAV_COMP_ID_PERIPHERAL,
+	"MAV_COMP_ID_QX1_GIMBAL":               MAV_COMP_ID_QX1_GIMBAL,
+	"MAV_COMP_ID_FLARM":                    MAV_COMP_ID_FLARM,
+	"MAV_COMP_ID_PARACHUTE":                MAV_COMP_ID_PARACHUTE,
+	"MAV_COMP_ID_WINCH":                    MAV_COMP_ID_WINCH,
+	"MAV_COMP_ID_GIMBAL2":                  MAV_COMP_ID_GIMBAL2,
+	"MAV_COMP_ID_GIMBAL3":                  MAV_COMP_ID_GIMBAL3,
+	"MAV_COMP_ID_GIMBAL4":                  MAV_COMP_ID_GIMBAL4,
+	"MAV_COMP_ID_GIMBAL5":                  MAV_COMP_ID_GIMBAL5,
+	"MAV_COMP_ID_GIMBAL6":                  MAV_COMP_ID_GIMBAL6,
+	"MAV_COMP_ID_BATTERY":                  MAV_COMP_ID_BATTERY,
+	"MAV_COMP_ID_BATTERY2":                 MAV_COMP_ID_BATTERY2,
+	"MAV_COMP_ID_MAVCAN":                   MAV_COMP_ID_MAVCAN,
+	"MAV_COMP_ID_MISSIONPLANNER":           MAV_COMP_ID_MISSIONPLANNER,
+	"MAV_COMP_ID_ONBOARD_COMPUTER":         MAV_COMP_ID_ONBOARD_COMPUTER,
+	"MAV_COMP_ID_ONBOARD_COMPUTER2":        MAV_COMP_ID_ONBOARD_COMPUTER2,
+	"MAV_COMP_ID_ONBOARD_COMPUTER3":        MAV_COMP_ID_ONBOARD_COMPUTER3,
+	"MAV_COMP_ID_ONBOARD_COMPUTER4":        MAV_COMP_ID_ONBOARD_COMPUTER4,
+	"MAV_COMP_ID_PATHPLANNER":              MAV_COMP_ID_PATHPLANNER,
+	"MAV_COMP_ID_OBSTACLE_AVOIDANCE":       MAV_COMP_ID_OBSTACLE_AVOIDANCE,
+	"MAV_COMP_ID_VISUAL_INERTIAL_ODOMETRY": MAV_COMP_ID_VISUAL_INERTIAL_ODOMETRY,
+	"MAV_COMP_ID_PAIRING_MANAGER":          MAV_COMP_ID_PAIRING_MANAGER,
+	"MAV_COMP_ID_IMU":                      MAV_COMP_ID_IMU,
+	"MAV_COMP_ID_IMU_2":                    MAV_COMP_ID_IMU_2,
+	"MAV_COMP_ID_IMU_3":                    MAV_COMP_ID_IMU_3,
+	"MAV_COMP_ID_GPS":                      MAV_COMP_ID_GPS,
+	"MAV_COMP_ID_GPS2":                     MAV_COMP_ID_GPS2,
+	"MAV_COMP_ID_ODID_TXRX_1":              MAV_COMP_ID_ODID_TXRX_1,
+	"MAV_COMP_ID_ODID_TXRX_2":              MAV_COMP_ID_ODID_TXRX_2,
+	"MAV_COMP_ID_ODID_TXRX_3":              MAV_COMP_ID_ODID_TXRX_3,
+	"MAV_COMP_ID_UDP_BRIDGE":               MAV_COMP_ID_UDP_BRIDGE,
+	"MAV_COMP_ID_UART_BRIDGE":              MAV_COMP_ID_UART_BRIDGE,
+	"MAV_COMP_ID_TUNNEL_NODE":              MAV_COMP_ID_TUNNEL_NODE,
+	"MAV_COMP_ID_SYSTEM_CONTROL":           MAV_COMP_ID_SYSTEM_CONTROL,
+}
+
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_COMPONENT) MarshalText() ([]byte, error) {
-	var names []string
-	for mask, label := range labels_MAV_COMPONENT {
-		if e&mask == mask {
-			names = append(names, label)
-		}
+	name, ok := labels_MAV_COMPONENT[e]
+	if !ok {
+		return nil, fmt.Errorf("invalid value %d", e)
 	}
-	return []byte(strings.Join(names, " | ")), nil
+	return []byte(name), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_COMPONENT) UnmarshalText(text []byte) error {
-	labels := strings.Split(string(text), " | ")
-	var mask MAV_COMPONENT
-	for _, label := range labels {
-		found := false
-		for value, l := range labels_MAV_COMPONENT {
-			if l == label {
-				mask |= value
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("invalid label '%s'", label)
-		}
+	value, ok := values_MAV_COMPONENT[string(text)]
+	if !ok {
+		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = mask
+	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_COMPONENT) String() string {
-	val, _ := e.MarshalText()
-	return string(val)
+	name, ok := labels_MAV_COMPONENT[e]
+	if !ok {
+		return strconv.Itoa(int(e))
+	}
+	return name
 }

--- a/pkg/dialects/minimal/enum_mav_mode_flag.go
+++ b/pkg/dialects/minimal/enum_mav_mode_flag.go
@@ -40,12 +40,24 @@ var labels_MAV_MODE_FLAG = map[MAV_MODE_FLAG]string{
 	MAV_MODE_FLAG_CUSTOM_MODE_ENABLED:  "MAV_MODE_FLAG_CUSTOM_MODE_ENABLED",
 }
 
+var values_MAV_MODE_FLAG = map[string]MAV_MODE_FLAG{
+	"MAV_MODE_FLAG_SAFETY_ARMED":         MAV_MODE_FLAG_SAFETY_ARMED,
+	"MAV_MODE_FLAG_MANUAL_INPUT_ENABLED": MAV_MODE_FLAG_MANUAL_INPUT_ENABLED,
+	"MAV_MODE_FLAG_HIL_ENABLED":          MAV_MODE_FLAG_HIL_ENABLED,
+	"MAV_MODE_FLAG_STABILIZE_ENABLED":    MAV_MODE_FLAG_STABILIZE_ENABLED,
+	"MAV_MODE_FLAG_GUIDED_ENABLED":       MAV_MODE_FLAG_GUIDED_ENABLED,
+	"MAV_MODE_FLAG_AUTO_ENABLED":         MAV_MODE_FLAG_AUTO_ENABLED,
+	"MAV_MODE_FLAG_TEST_ENABLED":         MAV_MODE_FLAG_TEST_ENABLED,
+	"MAV_MODE_FLAG_CUSTOM_MODE_ENABLED":  MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+}
+
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MODE_FLAG) MarshalText() ([]byte, error) {
 	var names []string
-	for mask, label := range labels_MAV_MODE_FLAG {
+	for i := 0; i < 8; i++ {
+		mask := MAV_MODE_FLAG(1 << i)
 		if e&mask == mask {
-			names = append(names, label)
+			names = append(names, labels_MAV_MODE_FLAG[mask])
 		}
 	}
 	return []byte(strings.Join(names, " | ")), nil
@@ -56,19 +68,12 @@ func (e *MAV_MODE_FLAG) UnmarshalText(text []byte) error {
 	labels := strings.Split(string(text), " | ")
 	var mask MAV_MODE_FLAG
 	for _, label := range labels {
-		found := false
-		for value, l := range labels_MAV_MODE_FLAG {
-			if l == label {
-				mask |= value
-				found = true
-				break
-			}
-		}
-		if !found {
+		if value, ok := values_MAV_MODE_FLAG[label]; ok {
+			mask |= value
+		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}
 	}
-	*e = mask
 	return nil
 }
 

--- a/pkg/dialects/minimal/enum_mav_mode_flag_decode_position.go
+++ b/pkg/dialects/minimal/enum_mav_mode_flag_decode_position.go
@@ -40,12 +40,24 @@ var labels_MAV_MODE_FLAG_DECODE_POSITION = map[MAV_MODE_FLAG_DECODE_POSITION]str
 	MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE: "MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE",
 }
 
+var values_MAV_MODE_FLAG_DECODE_POSITION = map[string]MAV_MODE_FLAG_DECODE_POSITION{
+	"MAV_MODE_FLAG_DECODE_POSITION_SAFETY":      MAV_MODE_FLAG_DECODE_POSITION_SAFETY,
+	"MAV_MODE_FLAG_DECODE_POSITION_MANUAL":      MAV_MODE_FLAG_DECODE_POSITION_MANUAL,
+	"MAV_MODE_FLAG_DECODE_POSITION_HIL":         MAV_MODE_FLAG_DECODE_POSITION_HIL,
+	"MAV_MODE_FLAG_DECODE_POSITION_STABILIZE":   MAV_MODE_FLAG_DECODE_POSITION_STABILIZE,
+	"MAV_MODE_FLAG_DECODE_POSITION_GUIDED":      MAV_MODE_FLAG_DECODE_POSITION_GUIDED,
+	"MAV_MODE_FLAG_DECODE_POSITION_AUTO":        MAV_MODE_FLAG_DECODE_POSITION_AUTO,
+	"MAV_MODE_FLAG_DECODE_POSITION_TEST":        MAV_MODE_FLAG_DECODE_POSITION_TEST,
+	"MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE": MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE,
+}
+
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MODE_FLAG_DECODE_POSITION) MarshalText() ([]byte, error) {
 	var names []string
-	for mask, label := range labels_MAV_MODE_FLAG_DECODE_POSITION {
+	for i := 0; i < 8; i++ {
+		mask := MAV_MODE_FLAG_DECODE_POSITION(1 << i)
 		if e&mask == mask {
-			names = append(names, label)
+			names = append(names, labels_MAV_MODE_FLAG_DECODE_POSITION[mask])
 		}
 	}
 	return []byte(strings.Join(names, " | ")), nil
@@ -56,19 +68,12 @@ func (e *MAV_MODE_FLAG_DECODE_POSITION) UnmarshalText(text []byte) error {
 	labels := strings.Split(string(text), " | ")
 	var mask MAV_MODE_FLAG_DECODE_POSITION
 	for _, label := range labels {
-		found := false
-		for value, l := range labels_MAV_MODE_FLAG_DECODE_POSITION {
-			if l == label {
-				mask |= value
-				found = true
-				break
-			}
-		}
-		if !found {
+		if value, ok := values_MAV_MODE_FLAG_DECODE_POSITION[label]; ok {
+			mask |= value
+		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}
 	}
-	*e = mask
 	return nil
 }
 

--- a/pkg/dialects/minimal/enum_mav_state.go
+++ b/pkg/dialects/minimal/enum_mav_state.go
@@ -4,7 +4,7 @@ package minimal
 
 import (
 	"fmt"
-	"strings"
+	"strconv"
 )
 
 type MAV_STATE uint32
@@ -42,40 +42,42 @@ var labels_MAV_STATE = map[MAV_STATE]string{
 	MAV_STATE_FLIGHT_TERMINATION: "MAV_STATE_FLIGHT_TERMINATION",
 }
 
+var values_MAV_STATE = map[string]MAV_STATE{
+	"MAV_STATE_UNINIT":             MAV_STATE_UNINIT,
+	"MAV_STATE_BOOT":               MAV_STATE_BOOT,
+	"MAV_STATE_CALIBRATING":        MAV_STATE_CALIBRATING,
+	"MAV_STATE_STANDBY":            MAV_STATE_STANDBY,
+	"MAV_STATE_ACTIVE":             MAV_STATE_ACTIVE,
+	"MAV_STATE_CRITICAL":           MAV_STATE_CRITICAL,
+	"MAV_STATE_EMERGENCY":          MAV_STATE_EMERGENCY,
+	"MAV_STATE_POWEROFF":           MAV_STATE_POWEROFF,
+	"MAV_STATE_FLIGHT_TERMINATION": MAV_STATE_FLIGHT_TERMINATION,
+}
+
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STATE) MarshalText() ([]byte, error) {
-	var names []string
-	for mask, label := range labels_MAV_STATE {
-		if e&mask == mask {
-			names = append(names, label)
-		}
+	name, ok := labels_MAV_STATE[e]
+	if !ok {
+		return nil, fmt.Errorf("invalid value %d", e)
 	}
-	return []byte(strings.Join(names, " | ")), nil
+	return []byte(name), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_STATE) UnmarshalText(text []byte) error {
-	labels := strings.Split(string(text), " | ")
-	var mask MAV_STATE
-	for _, label := range labels {
-		found := false
-		for value, l := range labels_MAV_STATE {
-			if l == label {
-				mask |= value
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("invalid label '%s'", label)
-		}
+	value, ok := values_MAV_STATE[string(text)]
+	if !ok {
+		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = mask
+	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_STATE) String() string {
-	val, _ := e.MarshalText()
-	return string(val)
+	name, ok := labels_MAV_STATE[e]
+	if !ok {
+		return strconv.Itoa(int(e))
+	}
+	return name
 }

--- a/pkg/dialects/minimal/enum_mav_type.go
+++ b/pkg/dialects/minimal/enum_mav_type.go
@@ -4,7 +4,7 @@ package minimal
 
 import (
 	"fmt"
-	"strings"
+	"strconv"
 )
 
 // MAVLINK component type reported in HEARTBEAT message. Flight controllers must report the type of the vehicle on which they are mounted (e.g. MAV_TYPE_OCTOROTOR). All other components must report a value appropriate for their type (e.g. a camera must use MAV_TYPE_CAMERA).
@@ -148,40 +148,77 @@ var labels_MAV_TYPE = map[MAV_TYPE]string{
 	MAV_TYPE_GENERIC_MULTIROTOR:        "MAV_TYPE_GENERIC_MULTIROTOR",
 }
 
+var values_MAV_TYPE = map[string]MAV_TYPE{
+	"MAV_TYPE_GENERIC":                   MAV_TYPE_GENERIC,
+	"MAV_TYPE_FIXED_WING":                MAV_TYPE_FIXED_WING,
+	"MAV_TYPE_QUADROTOR":                 MAV_TYPE_QUADROTOR,
+	"MAV_TYPE_COAXIAL":                   MAV_TYPE_COAXIAL,
+	"MAV_TYPE_HELICOPTER":                MAV_TYPE_HELICOPTER,
+	"MAV_TYPE_ANTENNA_TRACKER":           MAV_TYPE_ANTENNA_TRACKER,
+	"MAV_TYPE_GCS":                       MAV_TYPE_GCS,
+	"MAV_TYPE_AIRSHIP":                   MAV_TYPE_AIRSHIP,
+	"MAV_TYPE_FREE_BALLOON":              MAV_TYPE_FREE_BALLOON,
+	"MAV_TYPE_ROCKET":                    MAV_TYPE_ROCKET,
+	"MAV_TYPE_GROUND_ROVER":              MAV_TYPE_GROUND_ROVER,
+	"MAV_TYPE_SURFACE_BOAT":              MAV_TYPE_SURFACE_BOAT,
+	"MAV_TYPE_SUBMARINE":                 MAV_TYPE_SUBMARINE,
+	"MAV_TYPE_HEXAROTOR":                 MAV_TYPE_HEXAROTOR,
+	"MAV_TYPE_OCTOROTOR":                 MAV_TYPE_OCTOROTOR,
+	"MAV_TYPE_TRICOPTER":                 MAV_TYPE_TRICOPTER,
+	"MAV_TYPE_FLAPPING_WING":             MAV_TYPE_FLAPPING_WING,
+	"MAV_TYPE_KITE":                      MAV_TYPE_KITE,
+	"MAV_TYPE_ONBOARD_CONTROLLER":        MAV_TYPE_ONBOARD_CONTROLLER,
+	"MAV_TYPE_VTOL_TAILSITTER_DUOROTOR":  MAV_TYPE_VTOL_TAILSITTER_DUOROTOR,
+	"MAV_TYPE_VTOL_TAILSITTER_QUADROTOR": MAV_TYPE_VTOL_TAILSITTER_QUADROTOR,
+	"MAV_TYPE_VTOL_TILTROTOR":            MAV_TYPE_VTOL_TILTROTOR,
+	"MAV_TYPE_VTOL_FIXEDROTOR":           MAV_TYPE_VTOL_FIXEDROTOR,
+	"MAV_TYPE_VTOL_TAILSITTER":           MAV_TYPE_VTOL_TAILSITTER,
+	"MAV_TYPE_VTOL_TILTWING":             MAV_TYPE_VTOL_TILTWING,
+	"MAV_TYPE_VTOL_RESERVED5":            MAV_TYPE_VTOL_RESERVED5,
+	"MAV_TYPE_GIMBAL":                    MAV_TYPE_GIMBAL,
+	"MAV_TYPE_ADSB":                      MAV_TYPE_ADSB,
+	"MAV_TYPE_PARAFOIL":                  MAV_TYPE_PARAFOIL,
+	"MAV_TYPE_DODECAROTOR":               MAV_TYPE_DODECAROTOR,
+	"MAV_TYPE_CAMERA":                    MAV_TYPE_CAMERA,
+	"MAV_TYPE_CHARGING_STATION":          MAV_TYPE_CHARGING_STATION,
+	"MAV_TYPE_FLARM":                     MAV_TYPE_FLARM,
+	"MAV_TYPE_SERVO":                     MAV_TYPE_SERVO,
+	"MAV_TYPE_ODID":                      MAV_TYPE_ODID,
+	"MAV_TYPE_DECAROTOR":                 MAV_TYPE_DECAROTOR,
+	"MAV_TYPE_BATTERY":                   MAV_TYPE_BATTERY,
+	"MAV_TYPE_PARACHUTE":                 MAV_TYPE_PARACHUTE,
+	"MAV_TYPE_LOG":                       MAV_TYPE_LOG,
+	"MAV_TYPE_OSD":                       MAV_TYPE_OSD,
+	"MAV_TYPE_IMU":                       MAV_TYPE_IMU,
+	"MAV_TYPE_GPS":                       MAV_TYPE_GPS,
+	"MAV_TYPE_WINCH":                     MAV_TYPE_WINCH,
+	"MAV_TYPE_GENERIC_MULTIROTOR":        MAV_TYPE_GENERIC_MULTIROTOR,
+}
+
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_TYPE) MarshalText() ([]byte, error) {
-	var names []string
-	for mask, label := range labels_MAV_TYPE {
-		if e&mask == mask {
-			names = append(names, label)
-		}
+	name, ok := labels_MAV_TYPE[e]
+	if !ok {
+		return nil, fmt.Errorf("invalid value %d", e)
 	}
-	return []byte(strings.Join(names, " | ")), nil
+	return []byte(name), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_TYPE) UnmarshalText(text []byte) error {
-	labels := strings.Split(string(text), " | ")
-	var mask MAV_TYPE
-	for _, label := range labels {
-		found := false
-		for value, l := range labels_MAV_TYPE {
-			if l == label {
-				mask |= value
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("invalid label '%s'", label)
-		}
+	value, ok := values_MAV_TYPE[string(text)]
+	if !ok {
+		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = mask
+	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_TYPE) String() string {
-	val, _ := e.MarshalText()
-	return string(val)
+	name, ok := labels_MAV_TYPE[e]
+	if !ok {
+		return strconv.Itoa(int(e))
+	}
+	return name
 }


### PR DESCRIPTION
Fixes #79.

This PR updates the code generator to generate correct bitmask to strings.

It also makes the generated strings deterministic. Before this PR, the order of labels within a string was random (it depended on map iteration order, which is non-deterministic). This PR ensures that all labels within a string are in the order of the bits in the bitmask.

It also adds some code to format the generated files with `go fmt`.

I've only regenerated the minimal dialect so you can see what effect the changes have without receiving a huge PR. If you're happy with this then I can regenerate the other dialects.