### PR TITLE
Allow marshaling of invalid enum values

### DIFF
--- a/pkg/dialects/all/enum_mav_cmd.go
+++ b/pkg/dialects/all/enum_mav_cmd.go
@@ -934,28 +934,28 @@ var values_MAV_CMD = map[string]MAV_CMD{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_CMD[string(text)]
-	if !ok {
+	if value, ok := values_MAV_CMD[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_CMD(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD) String() string {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_accelcal_vehicle_pos.go
+++ b/pkg/dialects/ardupilotmega/enum_accelcal_vehicle_pos.go
@@ -44,28 +44,28 @@ var values_ACCELCAL_VEHICLE_POS = map[string]ACCELCAL_VEHICLE_POS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ACCELCAL_VEHICLE_POS) MarshalText() ([]byte, error) {
-	name, ok := labels_ACCELCAL_VEHICLE_POS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_ACCELCAL_VEHICLE_POS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ACCELCAL_VEHICLE_POS) UnmarshalText(text []byte) error {
-	value, ok := values_ACCELCAL_VEHICLE_POS[string(text)]
-	if !ok {
+	if value, ok := values_ACCELCAL_VEHICLE_POS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = ACCELCAL_VEHICLE_POS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ACCELCAL_VEHICLE_POS) String() string {
-	name, ok := labels_ACCELCAL_VEHICLE_POS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_ACCELCAL_VEHICLE_POS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_camera_feedback_flags.go
+++ b/pkg/dialects/ardupilotmega/enum_camera_feedback_flags.go
@@ -40,28 +40,28 @@ var values_CAMERA_FEEDBACK_FLAGS = map[string]CAMERA_FEEDBACK_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAMERA_FEEDBACK_FLAGS) MarshalText() ([]byte, error) {
-	name, ok := labels_CAMERA_FEEDBACK_FLAGS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_CAMERA_FEEDBACK_FLAGS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CAMERA_FEEDBACK_FLAGS) UnmarshalText(text []byte) error {
-	value, ok := values_CAMERA_FEEDBACK_FLAGS[string(text)]
-	if !ok {
+	if value, ok := values_CAMERA_FEEDBACK_FLAGS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = CAMERA_FEEDBACK_FLAGS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CAMERA_FEEDBACK_FLAGS) String() string {
-	name, ok := labels_CAMERA_FEEDBACK_FLAGS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_CAMERA_FEEDBACK_FLAGS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_camera_status_types.go
+++ b/pkg/dialects/ardupilotmega/enum_camera_status_types.go
@@ -48,28 +48,28 @@ var values_CAMERA_STATUS_TYPES = map[string]CAMERA_STATUS_TYPES{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAMERA_STATUS_TYPES) MarshalText() ([]byte, error) {
-	name, ok := labels_CAMERA_STATUS_TYPES[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_CAMERA_STATUS_TYPES[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CAMERA_STATUS_TYPES) UnmarshalText(text []byte) error {
-	value, ok := values_CAMERA_STATUS_TYPES[string(text)]
-	if !ok {
+	if value, ok := values_CAMERA_STATUS_TYPES[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = CAMERA_STATUS_TYPES(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CAMERA_STATUS_TYPES) String() string {
-	name, ok := labels_CAMERA_STATUS_TYPES[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_CAMERA_STATUS_TYPES[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_copter_mode.go
+++ b/pkg/dialects/ardupilotmega/enum_copter_mode.go
@@ -96,28 +96,28 @@ var values_COPTER_MODE = map[string]COPTER_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e COPTER_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_COPTER_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_COPTER_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *COPTER_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_COPTER_MODE[string(text)]
-	if !ok {
+	if value, ok := values_COPTER_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = COPTER_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e COPTER_MODE) String() string {
-	name, ok := labels_COPTER_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_COPTER_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_deepstall_stage.go
+++ b/pkg/dialects/ardupilotmega/enum_deepstall_stage.go
@@ -49,28 +49,28 @@ var values_DEEPSTALL_STAGE = map[string]DEEPSTALL_STAGE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e DEEPSTALL_STAGE) MarshalText() ([]byte, error) {
-	name, ok := labels_DEEPSTALL_STAGE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_DEEPSTALL_STAGE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *DEEPSTALL_STAGE) UnmarshalText(text []byte) error {
-	value, ok := values_DEEPSTALL_STAGE[string(text)]
-	if !ok {
+	if value, ok := values_DEEPSTALL_STAGE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = DEEPSTALL_STAGE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e DEEPSTALL_STAGE) String() string {
-	name, ok := labels_DEEPSTALL_STAGE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_DEEPSTALL_STAGE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_device_op_bustype.go
+++ b/pkg/dialects/ardupilotmega/enum_device_op_bustype.go
@@ -29,28 +29,28 @@ var values_DEVICE_OP_BUSTYPE = map[string]DEVICE_OP_BUSTYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e DEVICE_OP_BUSTYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_DEVICE_OP_BUSTYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_DEVICE_OP_BUSTYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *DEVICE_OP_BUSTYPE) UnmarshalText(text []byte) error {
-	value, ok := values_DEVICE_OP_BUSTYPE[string(text)]
-	if !ok {
+	if value, ok := values_DEVICE_OP_BUSTYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = DEVICE_OP_BUSTYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e DEVICE_OP_BUSTYPE) String() string {
-	name, ok := labels_DEVICE_OP_BUSTYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_DEVICE_OP_BUSTYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_ekf_status_flags.go
+++ b/pkg/dialects/ardupilotmega/enum_ekf_status_flags.go
@@ -4,6 +4,7 @@ package ardupilotmega
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -65,6 +66,9 @@ var values_EKF_STATUS_FLAGS = map[string]EKF_STATUS_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e EKF_STATUS_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 11; i++ {
 		mask := EKF_STATUS_FLAGS(1 << i)
@@ -82,6 +86,8 @@ func (e *EKF_STATUS_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_EKF_STATUS_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= EKF_STATUS_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/ardupilotmega/enum_gimbal_axis.go
+++ b/pkg/dialects/ardupilotmega/enum_gimbal_axis.go
@@ -32,28 +32,28 @@ var values_GIMBAL_AXIS = map[string]GIMBAL_AXIS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GIMBAL_AXIS) MarshalText() ([]byte, error) {
-	name, ok := labels_GIMBAL_AXIS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GIMBAL_AXIS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GIMBAL_AXIS) UnmarshalText(text []byte) error {
-	value, ok := values_GIMBAL_AXIS[string(text)]
-	if !ok {
+	if value, ok := values_GIMBAL_AXIS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GIMBAL_AXIS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GIMBAL_AXIS) String() string {
-	name, ok := labels_GIMBAL_AXIS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GIMBAL_AXIS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gimbal_axis_calibration_required.go
+++ b/pkg/dialects/ardupilotmega/enum_gimbal_axis_calibration_required.go
@@ -32,28 +32,28 @@ var values_GIMBAL_AXIS_CALIBRATION_REQUIRED = map[string]GIMBAL_AXIS_CALIBRATION
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GIMBAL_AXIS_CALIBRATION_REQUIRED) MarshalText() ([]byte, error) {
-	name, ok := labels_GIMBAL_AXIS_CALIBRATION_REQUIRED[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GIMBAL_AXIS_CALIBRATION_REQUIRED[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GIMBAL_AXIS_CALIBRATION_REQUIRED) UnmarshalText(text []byte) error {
-	value, ok := values_GIMBAL_AXIS_CALIBRATION_REQUIRED[string(text)]
-	if !ok {
+	if value, ok := values_GIMBAL_AXIS_CALIBRATION_REQUIRED[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GIMBAL_AXIS_CALIBRATION_REQUIRED(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GIMBAL_AXIS_CALIBRATION_REQUIRED) String() string {
-	name, ok := labels_GIMBAL_AXIS_CALIBRATION_REQUIRED[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GIMBAL_AXIS_CALIBRATION_REQUIRED[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gimbal_axis_calibration_status.go
+++ b/pkg/dialects/ardupilotmega/enum_gimbal_axis_calibration_status.go
@@ -32,28 +32,28 @@ var values_GIMBAL_AXIS_CALIBRATION_STATUS = map[string]GIMBAL_AXIS_CALIBRATION_S
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GIMBAL_AXIS_CALIBRATION_STATUS) MarshalText() ([]byte, error) {
-	name, ok := labels_GIMBAL_AXIS_CALIBRATION_STATUS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GIMBAL_AXIS_CALIBRATION_STATUS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GIMBAL_AXIS_CALIBRATION_STATUS) UnmarshalText(text []byte) error {
-	value, ok := values_GIMBAL_AXIS_CALIBRATION_STATUS[string(text)]
-	if !ok {
+	if value, ok := values_GIMBAL_AXIS_CALIBRATION_STATUS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GIMBAL_AXIS_CALIBRATION_STATUS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GIMBAL_AXIS_CALIBRATION_STATUS) String() string {
-	name, ok := labels_GIMBAL_AXIS_CALIBRATION_STATUS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GIMBAL_AXIS_CALIBRATION_STATUS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_burst_rate.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_burst_rate.go
@@ -56,28 +56,28 @@ var values_GOPRO_BURST_RATE = map[string]GOPRO_BURST_RATE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_BURST_RATE) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_BURST_RATE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_BURST_RATE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_BURST_RATE) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_BURST_RATE[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_BURST_RATE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_BURST_RATE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_BURST_RATE) String() string {
-	name, ok := labels_GOPRO_BURST_RATE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_BURST_RATE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_capture_mode.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_capture_mode.go
@@ -52,28 +52,28 @@ var values_GOPRO_CAPTURE_MODE = map[string]GOPRO_CAPTURE_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_CAPTURE_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_CAPTURE_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_CAPTURE_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_CAPTURE_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_CAPTURE_MODE[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_CAPTURE_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_CAPTURE_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_CAPTURE_MODE) String() string {
-	name, ok := labels_GOPRO_CAPTURE_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_CAPTURE_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_charging.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_charging.go
@@ -28,28 +28,28 @@ var values_GOPRO_CHARGING = map[string]GOPRO_CHARGING{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_CHARGING) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_CHARGING[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_CHARGING[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_CHARGING) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_CHARGING[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_CHARGING[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_CHARGING(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_CHARGING) String() string {
-	name, ok := labels_GOPRO_CHARGING[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_CHARGING[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_command.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_command.go
@@ -88,28 +88,28 @@ var values_GOPRO_COMMAND = map[string]GOPRO_COMMAND{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_COMMAND) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_COMMAND[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_COMMAND[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_COMMAND) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_COMMAND[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_COMMAND[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_COMMAND(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_COMMAND) String() string {
-	name, ok := labels_GOPRO_COMMAND[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_COMMAND[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_field_of_view.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_field_of_view.go
@@ -32,28 +32,28 @@ var values_GOPRO_FIELD_OF_VIEW = map[string]GOPRO_FIELD_OF_VIEW{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_FIELD_OF_VIEW) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_FIELD_OF_VIEW[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_FIELD_OF_VIEW[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_FIELD_OF_VIEW) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_FIELD_OF_VIEW[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_FIELD_OF_VIEW[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_FIELD_OF_VIEW(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_FIELD_OF_VIEW) String() string {
-	name, ok := labels_GOPRO_FIELD_OF_VIEW[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_FIELD_OF_VIEW[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_frame_rate.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_frame_rate.go
@@ -76,28 +76,28 @@ var values_GOPRO_FRAME_RATE = map[string]GOPRO_FRAME_RATE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_FRAME_RATE) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_FRAME_RATE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_FRAME_RATE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_FRAME_RATE) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_FRAME_RATE[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_FRAME_RATE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_FRAME_RATE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_FRAME_RATE) String() string {
-	name, ok := labels_GOPRO_FRAME_RATE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_FRAME_RATE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_heartbeat_flags.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_heartbeat_flags.go
@@ -4,6 +4,7 @@ package ardupilotmega
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -24,6 +25,9 @@ var values_GOPRO_HEARTBEAT_FLAGS = map[string]GOPRO_HEARTBEAT_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_HEARTBEAT_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 1; i++ {
 		mask := GOPRO_HEARTBEAT_FLAGS(1 << i)
@@ -41,6 +45,8 @@ func (e *GOPRO_HEARTBEAT_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_GOPRO_HEARTBEAT_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= GOPRO_HEARTBEAT_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/ardupilotmega/enum_gopro_heartbeat_status.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_heartbeat_status.go
@@ -36,28 +36,28 @@ var values_GOPRO_HEARTBEAT_STATUS = map[string]GOPRO_HEARTBEAT_STATUS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_HEARTBEAT_STATUS) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_HEARTBEAT_STATUS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_HEARTBEAT_STATUS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_HEARTBEAT_STATUS) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_HEARTBEAT_STATUS[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_HEARTBEAT_STATUS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_HEARTBEAT_STATUS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_HEARTBEAT_STATUS) String() string {
-	name, ok := labels_GOPRO_HEARTBEAT_STATUS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_HEARTBEAT_STATUS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_model.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_model.go
@@ -40,28 +40,28 @@ var values_GOPRO_MODEL = map[string]GOPRO_MODEL{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_MODEL) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_MODEL[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_MODEL[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_MODEL) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_MODEL[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_MODEL[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_MODEL(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_MODEL) String() string {
-	name, ok := labels_GOPRO_MODEL[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_MODEL[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_photo_resolution.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_photo_resolution.go
@@ -40,28 +40,28 @@ var values_GOPRO_PHOTO_RESOLUTION = map[string]GOPRO_PHOTO_RESOLUTION{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_PHOTO_RESOLUTION) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_PHOTO_RESOLUTION[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_PHOTO_RESOLUTION[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_PHOTO_RESOLUTION) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_PHOTO_RESOLUTION[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_PHOTO_RESOLUTION[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_PHOTO_RESOLUTION(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_PHOTO_RESOLUTION) String() string {
-	name, ok := labels_GOPRO_PHOTO_RESOLUTION[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_PHOTO_RESOLUTION[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_protune_colour.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_protune_colour.go
@@ -28,28 +28,28 @@ var values_GOPRO_PROTUNE_COLOUR = map[string]GOPRO_PROTUNE_COLOUR{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_PROTUNE_COLOUR) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_PROTUNE_COLOUR[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_PROTUNE_COLOUR[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_PROTUNE_COLOUR) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_PROTUNE_COLOUR[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_PROTUNE_COLOUR[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_PROTUNE_COLOUR(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_PROTUNE_COLOUR) String() string {
-	name, ok := labels_GOPRO_PROTUNE_COLOUR[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_PROTUNE_COLOUR[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_protune_exposure.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_protune_exposure.go
@@ -104,28 +104,28 @@ var values_GOPRO_PROTUNE_EXPOSURE = map[string]GOPRO_PROTUNE_EXPOSURE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_PROTUNE_EXPOSURE) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_PROTUNE_EXPOSURE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_PROTUNE_EXPOSURE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_PROTUNE_EXPOSURE) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_PROTUNE_EXPOSURE[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_PROTUNE_EXPOSURE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_PROTUNE_EXPOSURE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_PROTUNE_EXPOSURE) String() string {
-	name, ok := labels_GOPRO_PROTUNE_EXPOSURE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_PROTUNE_EXPOSURE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_protune_gain.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_protune_gain.go
@@ -40,28 +40,28 @@ var values_GOPRO_PROTUNE_GAIN = map[string]GOPRO_PROTUNE_GAIN{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_PROTUNE_GAIN) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_PROTUNE_GAIN[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_PROTUNE_GAIN[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_PROTUNE_GAIN) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_PROTUNE_GAIN[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_PROTUNE_GAIN[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_PROTUNE_GAIN(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_PROTUNE_GAIN) String() string {
-	name, ok := labels_GOPRO_PROTUNE_GAIN[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_PROTUNE_GAIN[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_protune_sharpness.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_protune_sharpness.go
@@ -32,28 +32,28 @@ var values_GOPRO_PROTUNE_SHARPNESS = map[string]GOPRO_PROTUNE_SHARPNESS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_PROTUNE_SHARPNESS) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_PROTUNE_SHARPNESS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_PROTUNE_SHARPNESS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_PROTUNE_SHARPNESS) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_PROTUNE_SHARPNESS[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_PROTUNE_SHARPNESS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_PROTUNE_SHARPNESS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_PROTUNE_SHARPNESS) String() string {
-	name, ok := labels_GOPRO_PROTUNE_SHARPNESS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_PROTUNE_SHARPNESS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_protune_white_balance.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_protune_white_balance.go
@@ -40,28 +40,28 @@ var values_GOPRO_PROTUNE_WHITE_BALANCE = map[string]GOPRO_PROTUNE_WHITE_BALANCE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_PROTUNE_WHITE_BALANCE) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_PROTUNE_WHITE_BALANCE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_PROTUNE_WHITE_BALANCE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_PROTUNE_WHITE_BALANCE) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_PROTUNE_WHITE_BALANCE[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_PROTUNE_WHITE_BALANCE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_PROTUNE_WHITE_BALANCE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_PROTUNE_WHITE_BALANCE) String() string {
-	name, ok := labels_GOPRO_PROTUNE_WHITE_BALANCE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_PROTUNE_WHITE_BALANCE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_request_status.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_request_status.go
@@ -28,28 +28,28 @@ var values_GOPRO_REQUEST_STATUS = map[string]GOPRO_REQUEST_STATUS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_REQUEST_STATUS) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_REQUEST_STATUS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_REQUEST_STATUS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_REQUEST_STATUS) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_REQUEST_STATUS[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_REQUEST_STATUS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_REQUEST_STATUS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_REQUEST_STATUS) String() string {
-	name, ok := labels_GOPRO_REQUEST_STATUS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_REQUEST_STATUS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_resolution.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_resolution.go
@@ -76,28 +76,28 @@ var values_GOPRO_RESOLUTION = map[string]GOPRO_RESOLUTION{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_RESOLUTION) MarshalText() ([]byte, error) {
-	name, ok := labels_GOPRO_RESOLUTION[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GOPRO_RESOLUTION[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GOPRO_RESOLUTION) UnmarshalText(text []byte) error {
-	value, ok := values_GOPRO_RESOLUTION[string(text)]
-	if !ok {
+	if value, ok := values_GOPRO_RESOLUTION[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GOPRO_RESOLUTION(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GOPRO_RESOLUTION) String() string {
-	name, ok := labels_GOPRO_RESOLUTION[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GOPRO_RESOLUTION[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_gopro_video_settings_flags.go
+++ b/pkg/dialects/ardupilotmega/enum_gopro_video_settings_flags.go
@@ -4,6 +4,7 @@ package ardupilotmega
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -24,6 +25,9 @@ var values_GOPRO_VIDEO_SETTINGS_FLAGS = map[string]GOPRO_VIDEO_SETTINGS_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GOPRO_VIDEO_SETTINGS_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 1; i++ {
 		mask := GOPRO_VIDEO_SETTINGS_FLAGS(1 << i)
@@ -41,6 +45,8 @@ func (e *GOPRO_VIDEO_SETTINGS_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_GOPRO_VIDEO_SETTINGS_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= GOPRO_VIDEO_SETTINGS_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/ardupilotmega/enum_heading_type.go
+++ b/pkg/dialects/ardupilotmega/enum_heading_type.go
@@ -26,28 +26,28 @@ var values_HEADING_TYPE = map[string]HEADING_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e HEADING_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_HEADING_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_HEADING_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *HEADING_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_HEADING_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_HEADING_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = HEADING_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e HEADING_TYPE) String() string {
-	name, ok := labels_HEADING_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_HEADING_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_led_control_pattern.go
+++ b/pkg/dialects/ardupilotmega/enum_led_control_pattern.go
@@ -32,28 +32,28 @@ var values_LED_CONTROL_PATTERN = map[string]LED_CONTROL_PATTERN{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e LED_CONTROL_PATTERN) MarshalText() ([]byte, error) {
-	name, ok := labels_LED_CONTROL_PATTERN[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_LED_CONTROL_PATTERN[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *LED_CONTROL_PATTERN) UnmarshalText(text []byte) error {
-	value, ok := values_LED_CONTROL_PATTERN[string(text)]
-	if !ok {
+	if value, ok := values_LED_CONTROL_PATTERN[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = LED_CONTROL_PATTERN(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e LED_CONTROL_PATTERN) String() string {
-	name, ok := labels_LED_CONTROL_PATTERN[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_LED_CONTROL_PATTERN[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_limit_module.go
+++ b/pkg/dialects/ardupilotmega/enum_limit_module.go
@@ -4,6 +4,7 @@ package ardupilotmega
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -32,6 +33,9 @@ var values_LIMIT_MODULE = map[string]LIMIT_MODULE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e LIMIT_MODULE) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 3; i++ {
 		mask := LIMIT_MODULE(1 << i)
@@ -49,6 +53,8 @@ func (e *LIMIT_MODULE) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_LIMIT_MODULE[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= LIMIT_MODULE(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/ardupilotmega/enum_limits_state.go
+++ b/pkg/dialects/ardupilotmega/enum_limits_state.go
@@ -44,28 +44,28 @@ var values_LIMITS_STATE = map[string]LIMITS_STATE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e LIMITS_STATE) MarshalText() ([]byte, error) {
-	name, ok := labels_LIMITS_STATE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_LIMITS_STATE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *LIMITS_STATE) UnmarshalText(text []byte) error {
-	value, ok := values_LIMITS_STATE[string(text)]
-	if !ok {
+	if value, ok := values_LIMITS_STATE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = LIMITS_STATE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e LIMITS_STATE) String() string {
-	name, ok := labels_LIMITS_STATE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_LIMITS_STATE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_mav_cmd.go
+++ b/pkg/dialects/ardupilotmega/enum_mav_cmd.go
@@ -835,28 +835,28 @@ var values_MAV_CMD = map[string]MAV_CMD{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_CMD[string(text)]
-	if !ok {
+	if value, ok := values_MAV_CMD[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_CMD(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD) String() string {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_mav_cmd_do_aux_function_switch_level.go
+++ b/pkg/dialects/ardupilotmega/enum_mav_cmd_do_aux_function_switch_level.go
@@ -32,28 +32,28 @@ var values_MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL = map[string]MAV_CMD_DO_AUX_FUNC
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL[string(text)]
-	if !ok {
+	if value, ok := values_MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL) String() string {
-	name, ok := labels_MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_mav_mode_gimbal.go
+++ b/pkg/dialects/ardupilotmega/enum_mav_mode_gimbal.go
@@ -48,28 +48,28 @@ var values_MAV_MODE_GIMBAL = map[string]MAV_MODE_GIMBAL{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MODE_GIMBAL) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_MODE_GIMBAL[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_MODE_GIMBAL[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_MODE_GIMBAL) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_MODE_GIMBAL[string(text)]
-	if !ok {
+	if value, ok := values_MAV_MODE_GIMBAL[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_MODE_GIMBAL(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_MODE_GIMBAL) String() string {
-	name, ok := labels_MAV_MODE_GIMBAL[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_MODE_GIMBAL[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_mav_remote_log_data_block_commands.go
+++ b/pkg/dialects/ardupilotmega/enum_mav_remote_log_data_block_commands.go
@@ -29,28 +29,28 @@ var values_MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS = map[string]MAV_REMOTE_LOG_DATA_B
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS[string(text)]
-	if !ok {
+	if value, ok := values_MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS) String() string {
-	name, ok := labels_MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_mav_remote_log_data_block_statuses.go
+++ b/pkg/dialects/ardupilotmega/enum_mav_remote_log_data_block_statuses.go
@@ -29,28 +29,28 @@ var values_MAV_REMOTE_LOG_DATA_BLOCK_STATUSES = map[string]MAV_REMOTE_LOG_DATA_B
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_REMOTE_LOG_DATA_BLOCK_STATUSES) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_REMOTE_LOG_DATA_BLOCK_STATUSES[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_REMOTE_LOG_DATA_BLOCK_STATUSES[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_REMOTE_LOG_DATA_BLOCK_STATUSES) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_REMOTE_LOG_DATA_BLOCK_STATUSES[string(text)]
-	if !ok {
+	if value, ok := values_MAV_REMOTE_LOG_DATA_BLOCK_STATUSES[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_REMOTE_LOG_DATA_BLOCK_STATUSES(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_REMOTE_LOG_DATA_BLOCK_STATUSES) String() string {
-	name, ok := labels_MAV_REMOTE_LOG_DATA_BLOCK_STATUSES[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_REMOTE_LOG_DATA_BLOCK_STATUSES[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_osd_param_config_error.go
+++ b/pkg/dialects/ardupilotmega/enum_osd_param_config_error.go
@@ -33,28 +33,28 @@ var values_OSD_PARAM_CONFIG_ERROR = map[string]OSD_PARAM_CONFIG_ERROR{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e OSD_PARAM_CONFIG_ERROR) MarshalText() ([]byte, error) {
-	name, ok := labels_OSD_PARAM_CONFIG_ERROR[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_OSD_PARAM_CONFIG_ERROR[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *OSD_PARAM_CONFIG_ERROR) UnmarshalText(text []byte) error {
-	value, ok := values_OSD_PARAM_CONFIG_ERROR[string(text)]
-	if !ok {
+	if value, ok := values_OSD_PARAM_CONFIG_ERROR[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = OSD_PARAM_CONFIG_ERROR(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e OSD_PARAM_CONFIG_ERROR) String() string {
-	name, ok := labels_OSD_PARAM_CONFIG_ERROR[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_OSD_PARAM_CONFIG_ERROR[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_osd_param_config_type.go
+++ b/pkg/dialects/ardupilotmega/enum_osd_param_config_type.go
@@ -48,28 +48,28 @@ var values_OSD_PARAM_CONFIG_TYPE = map[string]OSD_PARAM_CONFIG_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e OSD_PARAM_CONFIG_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_OSD_PARAM_CONFIG_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_OSD_PARAM_CONFIG_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *OSD_PARAM_CONFIG_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_OSD_PARAM_CONFIG_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_OSD_PARAM_CONFIG_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = OSD_PARAM_CONFIG_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e OSD_PARAM_CONFIG_TYPE) String() string {
-	name, ok := labels_OSD_PARAM_CONFIG_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_OSD_PARAM_CONFIG_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_pid_tuning_axis.go
+++ b/pkg/dialects/ardupilotmega/enum_pid_tuning_axis.go
@@ -38,28 +38,28 @@ var values_PID_TUNING_AXIS = map[string]PID_TUNING_AXIS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PID_TUNING_AXIS) MarshalText() ([]byte, error) {
-	name, ok := labels_PID_TUNING_AXIS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_PID_TUNING_AXIS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PID_TUNING_AXIS) UnmarshalText(text []byte) error {
-	value, ok := values_PID_TUNING_AXIS[string(text)]
-	if !ok {
+	if value, ok := values_PID_TUNING_AXIS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = PID_TUNING_AXIS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PID_TUNING_AXIS) String() string {
-	name, ok := labels_PID_TUNING_AXIS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_PID_TUNING_AXIS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_plane_mode.go
+++ b/pkg/dialects/ardupilotmega/enum_plane_mode.go
@@ -93,28 +93,28 @@ var values_PLANE_MODE = map[string]PLANE_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PLANE_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_PLANE_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_PLANE_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PLANE_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_PLANE_MODE[string(text)]
-	if !ok {
+	if value, ok := values_PLANE_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = PLANE_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PLANE_MODE) String() string {
-	name, ok := labels_PLANE_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_PLANE_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_rally_flags.go
+++ b/pkg/dialects/ardupilotmega/enum_rally_flags.go
@@ -4,6 +4,7 @@ package ardupilotmega
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -29,6 +30,9 @@ var values_RALLY_FLAGS = map[string]RALLY_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e RALLY_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 2; i++ {
 		mask := RALLY_FLAGS(1 << i)
@@ -46,6 +50,8 @@ func (e *RALLY_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_RALLY_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= RALLY_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/ardupilotmega/enum_rover_mode.go
+++ b/pkg/dialects/ardupilotmega/enum_rover_mode.go
@@ -57,28 +57,28 @@ var values_ROVER_MODE = map[string]ROVER_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ROVER_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_ROVER_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_ROVER_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ROVER_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_ROVER_MODE[string(text)]
-	if !ok {
+	if value, ok := values_ROVER_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = ROVER_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ROVER_MODE) String() string {
-	name, ok := labels_ROVER_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_ROVER_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_scripting_cmd.go
+++ b/pkg/dialects/ardupilotmega/enum_scripting_cmd.go
@@ -36,28 +36,28 @@ var values_SCRIPTING_CMD = map[string]SCRIPTING_CMD{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e SCRIPTING_CMD) MarshalText() ([]byte, error) {
-	name, ok := labels_SCRIPTING_CMD[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_SCRIPTING_CMD[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *SCRIPTING_CMD) UnmarshalText(text []byte) error {
-	value, ok := values_SCRIPTING_CMD[string(text)]
-	if !ok {
+	if value, ok := values_SCRIPTING_CMD[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = SCRIPTING_CMD(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e SCRIPTING_CMD) String() string {
-	name, ok := labels_SCRIPTING_CMD[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_SCRIPTING_CMD[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_sub_mode.go
+++ b/pkg/dialects/ardupilotmega/enum_sub_mode.go
@@ -48,28 +48,28 @@ var values_SUB_MODE = map[string]SUB_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e SUB_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_SUB_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_SUB_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *SUB_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_SUB_MODE[string(text)]
-	if !ok {
+	if value, ok := values_SUB_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = SUB_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e SUB_MODE) String() string {
-	name, ok := labels_SUB_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_SUB_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ardupilotmega/enum_tracker_mode.go
+++ b/pkg/dialects/ardupilotmega/enum_tracker_mode.go
@@ -39,28 +39,28 @@ var values_TRACKER_MODE = map[string]TRACKER_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e TRACKER_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_TRACKER_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_TRACKER_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *TRACKER_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_TRACKER_MODE[string(text)]
-	if !ok {
+	if value, ok := values_TRACKER_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = TRACKER_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e TRACKER_MODE) String() string {
-	name, ok := labels_TRACKER_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_TRACKER_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/asluav/enum_gsm_link_type.go
+++ b/pkg/dialects/asluav/enum_gsm_link_type.go
@@ -40,28 +40,28 @@ var values_GSM_LINK_TYPE = map[string]GSM_LINK_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GSM_LINK_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_GSM_LINK_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GSM_LINK_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GSM_LINK_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_GSM_LINK_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_GSM_LINK_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GSM_LINK_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GSM_LINK_TYPE) String() string {
-	name, ok := labels_GSM_LINK_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GSM_LINK_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/asluav/enum_gsm_modem_type.go
+++ b/pkg/dialects/asluav/enum_gsm_modem_type.go
@@ -28,28 +28,28 @@ var values_GSM_MODEM_TYPE = map[string]GSM_MODEM_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GSM_MODEM_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_GSM_MODEM_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GSM_MODEM_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GSM_MODEM_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_GSM_MODEM_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_GSM_MODEM_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GSM_MODEM_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GSM_MODEM_TYPE) String() string {
-	name, ok := labels_GSM_MODEM_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GSM_MODEM_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/asluav/enum_mav_cmd.go
+++ b/pkg/dialects/asluav/enum_mav_cmd.go
@@ -714,28 +714,28 @@ var values_MAV_CMD = map[string]MAV_CMD{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_CMD[string(text)]
-	if !ok {
+	if value, ok := values_MAV_CMD[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_CMD(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD) String() string {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/avssuas/enum_avss_horsefly_operation_mode.go
+++ b/pkg/dialects/avssuas/enum_avss_horsefly_operation_mode.go
@@ -40,28 +40,28 @@ var values_AVSS_HORSEFLY_OPERATION_MODE = map[string]AVSS_HORSEFLY_OPERATION_MOD
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e AVSS_HORSEFLY_OPERATION_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_AVSS_HORSEFLY_OPERATION_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_AVSS_HORSEFLY_OPERATION_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *AVSS_HORSEFLY_OPERATION_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_AVSS_HORSEFLY_OPERATION_MODE[string(text)]
-	if !ok {
+	if value, ok := values_AVSS_HORSEFLY_OPERATION_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = AVSS_HORSEFLY_OPERATION_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e AVSS_HORSEFLY_OPERATION_MODE) String() string {
-	name, ok := labels_AVSS_HORSEFLY_OPERATION_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_AVSS_HORSEFLY_OPERATION_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/avssuas/enum_avss_m300_operation_mode.go
+++ b/pkg/dialects/avssuas/enum_avss_m300_operation_mode.go
@@ -76,28 +76,28 @@ var values_AVSS_M300_OPERATION_MODE = map[string]AVSS_M300_OPERATION_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e AVSS_M300_OPERATION_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_AVSS_M300_OPERATION_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_AVSS_M300_OPERATION_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *AVSS_M300_OPERATION_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_AVSS_M300_OPERATION_MODE[string(text)]
-	if !ok {
+	if value, ok := values_AVSS_M300_OPERATION_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = AVSS_M300_OPERATION_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e AVSS_M300_OPERATION_MODE) String() string {
-	name, ok := labels_AVSS_M300_OPERATION_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_AVSS_M300_OPERATION_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/avssuas/enum_mav_avss_command_failure_reason.go
+++ b/pkg/dialects/avssuas/enum_mav_avss_command_failure_reason.go
@@ -32,28 +32,28 @@ var values_MAV_AVSS_COMMAND_FAILURE_REASON = map[string]MAV_AVSS_COMMAND_FAILURE
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_AVSS_COMMAND_FAILURE_REASON) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_AVSS_COMMAND_FAILURE_REASON[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_AVSS_COMMAND_FAILURE_REASON[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_AVSS_COMMAND_FAILURE_REASON) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_AVSS_COMMAND_FAILURE_REASON[string(text)]
-	if !ok {
+	if value, ok := values_MAV_AVSS_COMMAND_FAILURE_REASON[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_AVSS_COMMAND_FAILURE_REASON(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_AVSS_COMMAND_FAILURE_REASON) String() string {
-	name, ok := labels_MAV_AVSS_COMMAND_FAILURE_REASON[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_AVSS_COMMAND_FAILURE_REASON[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/avssuas/enum_mav_cmd.go
+++ b/pkg/dialects/avssuas/enum_mav_cmd.go
@@ -734,28 +734,28 @@ var values_MAV_CMD = map[string]MAV_CMD{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_CMD[string(text)]
-	if !ok {
+	if value, ok := values_MAV_CMD[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_CMD(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD) String() string {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_actuator_configuration.go
+++ b/pkg/dialects/common/enum_actuator_configuration.go
@@ -45,28 +45,28 @@ var values_ACTUATOR_CONFIGURATION = map[string]ACTUATOR_CONFIGURATION{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ACTUATOR_CONFIGURATION) MarshalText() ([]byte, error) {
-	name, ok := labels_ACTUATOR_CONFIGURATION[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_ACTUATOR_CONFIGURATION[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ACTUATOR_CONFIGURATION) UnmarshalText(text []byte) error {
-	value, ok := values_ACTUATOR_CONFIGURATION[string(text)]
-	if !ok {
+	if value, ok := values_ACTUATOR_CONFIGURATION[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = ACTUATOR_CONFIGURATION(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ACTUATOR_CONFIGURATION) String() string {
-	name, ok := labels_ACTUATOR_CONFIGURATION[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_ACTUATOR_CONFIGURATION[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_actuator_output_function.go
+++ b/pkg/dialects/common/enum_actuator_output_function.go
@@ -153,28 +153,28 @@ var values_ACTUATOR_OUTPUT_FUNCTION = map[string]ACTUATOR_OUTPUT_FUNCTION{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ACTUATOR_OUTPUT_FUNCTION) MarshalText() ([]byte, error) {
-	name, ok := labels_ACTUATOR_OUTPUT_FUNCTION[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_ACTUATOR_OUTPUT_FUNCTION[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ACTUATOR_OUTPUT_FUNCTION) UnmarshalText(text []byte) error {
-	value, ok := values_ACTUATOR_OUTPUT_FUNCTION[string(text)]
-	if !ok {
+	if value, ok := values_ACTUATOR_OUTPUT_FUNCTION[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = ACTUATOR_OUTPUT_FUNCTION(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ACTUATOR_OUTPUT_FUNCTION) String() string {
-	name, ok := labels_ACTUATOR_OUTPUT_FUNCTION[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_ACTUATOR_OUTPUT_FUNCTION[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_adsb_altitude_type.go
+++ b/pkg/dialects/common/enum_adsb_altitude_type.go
@@ -29,28 +29,28 @@ var values_ADSB_ALTITUDE_TYPE = map[string]ADSB_ALTITUDE_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ADSB_ALTITUDE_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_ADSB_ALTITUDE_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_ADSB_ALTITUDE_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ADSB_ALTITUDE_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_ADSB_ALTITUDE_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_ADSB_ALTITUDE_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = ADSB_ALTITUDE_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ADSB_ALTITUDE_TYPE) String() string {
-	name, ok := labels_ADSB_ALTITUDE_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_ADSB_ALTITUDE_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_adsb_emitter_type.go
+++ b/pkg/dialects/common/enum_adsb_emitter_type.go
@@ -81,28 +81,28 @@ var values_ADSB_EMITTER_TYPE = map[string]ADSB_EMITTER_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ADSB_EMITTER_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_ADSB_EMITTER_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_ADSB_EMITTER_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ADSB_EMITTER_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_ADSB_EMITTER_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_ADSB_EMITTER_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = ADSB_EMITTER_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ADSB_EMITTER_TYPE) String() string {
-	name, ok := labels_ADSB_EMITTER_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_ADSB_EMITTER_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_adsb_flags.go
+++ b/pkg/dialects/common/enum_adsb_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -51,6 +52,9 @@ var values_ADSB_FLAGS = map[string]ADSB_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ADSB_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 10; i++ {
 		mask := ADSB_FLAGS(1 << i)
@@ -68,6 +72,8 @@ func (e *ADSB_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_ADSB_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= ADSB_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_ais_flags.go
+++ b/pkg/dialects/common/enum_ais_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -67,6 +68,9 @@ var values_AIS_FLAGS = map[string]AIS_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e AIS_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 13; i++ {
 		mask := AIS_FLAGS(1 << i)
@@ -84,6 +88,8 @@ func (e *AIS_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_AIS_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= AIS_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_ais_nav_status.go
+++ b/pkg/dialects/common/enum_ais_nav_status.go
@@ -72,28 +72,28 @@ var values_AIS_NAV_STATUS = map[string]AIS_NAV_STATUS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e AIS_NAV_STATUS) MarshalText() ([]byte, error) {
-	name, ok := labels_AIS_NAV_STATUS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_AIS_NAV_STATUS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *AIS_NAV_STATUS) UnmarshalText(text []byte) error {
-	value, ok := values_AIS_NAV_STATUS[string(text)]
-	if !ok {
+	if value, ok := values_AIS_NAV_STATUS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = AIS_NAV_STATUS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e AIS_NAV_STATUS) String() string {
-	name, ok := labels_AIS_NAV_STATUS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_AIS_NAV_STATUS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_ais_type.go
+++ b/pkg/dialects/common/enum_ais_type.go
@@ -329,28 +329,28 @@ var values_AIS_TYPE = map[string]AIS_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e AIS_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_AIS_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_AIS_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *AIS_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_AIS_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_AIS_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = AIS_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e AIS_TYPE) String() string {
-	name, ok := labels_AIS_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_AIS_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_attitude_target_typemask.go
+++ b/pkg/dialects/common/enum_attitude_target_typemask.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -45,6 +46,9 @@ var values_ATTITUDE_TARGET_TYPEMASK = map[string]ATTITUDE_TARGET_TYPEMASK{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ATTITUDE_TARGET_TYPEMASK) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 6; i++ {
 		mask := ATTITUDE_TARGET_TYPEMASK(1 << i)
@@ -62,6 +66,8 @@ func (e *ATTITUDE_TARGET_TYPEMASK) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_ATTITUDE_TARGET_TYPEMASK[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= ATTITUDE_TARGET_TYPEMASK(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_autotune_axis.go
+++ b/pkg/dialects/common/enum_autotune_axis.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -37,6 +38,9 @@ var values_AUTOTUNE_AXIS = map[string]AUTOTUNE_AXIS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e AUTOTUNE_AXIS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 4; i++ {
 		mask := AUTOTUNE_AXIS(1 << i)
@@ -54,6 +58,8 @@ func (e *AUTOTUNE_AXIS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_AUTOTUNE_AXIS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= AUTOTUNE_AXIS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_camera_cap_flags.go
+++ b/pkg/dialects/common/enum_camera_cap_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -69,6 +70,9 @@ var values_CAMERA_CAP_FLAGS = map[string]CAMERA_CAP_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAMERA_CAP_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 12; i++ {
 		mask := CAMERA_CAP_FLAGS(1 << i)
@@ -86,6 +90,8 @@ func (e *CAMERA_CAP_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_CAMERA_CAP_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= CAMERA_CAP_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_camera_mode.go
+++ b/pkg/dialects/common/enum_camera_mode.go
@@ -33,28 +33,28 @@ var values_CAMERA_MODE = map[string]CAMERA_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAMERA_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_CAMERA_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_CAMERA_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CAMERA_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_CAMERA_MODE[string(text)]
-	if !ok {
+	if value, ok := values_CAMERA_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = CAMERA_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CAMERA_MODE) String() string {
-	name, ok := labels_CAMERA_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_CAMERA_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_camera_tracking_mode.go
+++ b/pkg/dialects/common/enum_camera_tracking_mode.go
@@ -33,28 +33,28 @@ var values_CAMERA_TRACKING_MODE = map[string]CAMERA_TRACKING_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAMERA_TRACKING_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_CAMERA_TRACKING_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_CAMERA_TRACKING_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CAMERA_TRACKING_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_CAMERA_TRACKING_MODE[string(text)]
-	if !ok {
+	if value, ok := values_CAMERA_TRACKING_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = CAMERA_TRACKING_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CAMERA_TRACKING_MODE) String() string {
-	name, ok := labels_CAMERA_TRACKING_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_CAMERA_TRACKING_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_camera_tracking_status_flags.go
+++ b/pkg/dialects/common/enum_camera_tracking_status_flags.go
@@ -33,28 +33,28 @@ var values_CAMERA_TRACKING_STATUS_FLAGS = map[string]CAMERA_TRACKING_STATUS_FLAG
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAMERA_TRACKING_STATUS_FLAGS) MarshalText() ([]byte, error) {
-	name, ok := labels_CAMERA_TRACKING_STATUS_FLAGS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_CAMERA_TRACKING_STATUS_FLAGS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CAMERA_TRACKING_STATUS_FLAGS) UnmarshalText(text []byte) error {
-	value, ok := values_CAMERA_TRACKING_STATUS_FLAGS[string(text)]
-	if !ok {
+	if value, ok := values_CAMERA_TRACKING_STATUS_FLAGS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = CAMERA_TRACKING_STATUS_FLAGS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CAMERA_TRACKING_STATUS_FLAGS) String() string {
-	name, ok := labels_CAMERA_TRACKING_STATUS_FLAGS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_CAMERA_TRACKING_STATUS_FLAGS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_camera_tracking_target_data.go
+++ b/pkg/dialects/common/enum_camera_tracking_target_data.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -37,6 +38,9 @@ var values_CAMERA_TRACKING_TARGET_DATA = map[string]CAMERA_TRACKING_TARGET_DATA{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAMERA_TRACKING_TARGET_DATA) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 4; i++ {
 		mask := CAMERA_TRACKING_TARGET_DATA(1 << i)
@@ -54,6 +58,8 @@ func (e *CAMERA_TRACKING_TARGET_DATA) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_CAMERA_TRACKING_TARGET_DATA[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= CAMERA_TRACKING_TARGET_DATA(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_camera_zoom_type.go
+++ b/pkg/dialects/common/enum_camera_zoom_type.go
@@ -41,28 +41,28 @@ var values_CAMERA_ZOOM_TYPE = map[string]CAMERA_ZOOM_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAMERA_ZOOM_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_CAMERA_ZOOM_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_CAMERA_ZOOM_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CAMERA_ZOOM_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_CAMERA_ZOOM_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_CAMERA_ZOOM_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = CAMERA_ZOOM_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CAMERA_ZOOM_TYPE) String() string {
-	name, ok := labels_CAMERA_ZOOM_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_CAMERA_ZOOM_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_can_filter_op.go
+++ b/pkg/dialects/common/enum_can_filter_op.go
@@ -29,28 +29,28 @@ var values_CAN_FILTER_OP = map[string]CAN_FILTER_OP{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CAN_FILTER_OP) MarshalText() ([]byte, error) {
-	name, ok := labels_CAN_FILTER_OP[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_CAN_FILTER_OP[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CAN_FILTER_OP) UnmarshalText(text []byte) error {
-	value, ok := values_CAN_FILTER_OP[string(text)]
-	if !ok {
+	if value, ok := values_CAN_FILTER_OP[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = CAN_FILTER_OP(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CAN_FILTER_OP) String() string {
-	name, ok := labels_CAN_FILTER_OP[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_CAN_FILTER_OP[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_cellular_config_response.go
+++ b/pkg/dialects/common/enum_cellular_config_response.go
@@ -41,28 +41,28 @@ var values_CELLULAR_CONFIG_RESPONSE = map[string]CELLULAR_CONFIG_RESPONSE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CELLULAR_CONFIG_RESPONSE) MarshalText() ([]byte, error) {
-	name, ok := labels_CELLULAR_CONFIG_RESPONSE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_CELLULAR_CONFIG_RESPONSE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CELLULAR_CONFIG_RESPONSE) UnmarshalText(text []byte) error {
-	value, ok := values_CELLULAR_CONFIG_RESPONSE[string(text)]
-	if !ok {
+	if value, ok := values_CELLULAR_CONFIG_RESPONSE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = CELLULAR_CONFIG_RESPONSE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CELLULAR_CONFIG_RESPONSE) String() string {
-	name, ok := labels_CELLULAR_CONFIG_RESPONSE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_CELLULAR_CONFIG_RESPONSE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_cellular_network_failed_reason.go
+++ b/pkg/dialects/common/enum_cellular_network_failed_reason.go
@@ -37,28 +37,28 @@ var values_CELLULAR_NETWORK_FAILED_REASON = map[string]CELLULAR_NETWORK_FAILED_R
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CELLULAR_NETWORK_FAILED_REASON) MarshalText() ([]byte, error) {
-	name, ok := labels_CELLULAR_NETWORK_FAILED_REASON[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_CELLULAR_NETWORK_FAILED_REASON[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CELLULAR_NETWORK_FAILED_REASON) UnmarshalText(text []byte) error {
-	value, ok := values_CELLULAR_NETWORK_FAILED_REASON[string(text)]
-	if !ok {
+	if value, ok := values_CELLULAR_NETWORK_FAILED_REASON[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = CELLULAR_NETWORK_FAILED_REASON(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CELLULAR_NETWORK_FAILED_REASON) String() string {
-	name, ok := labels_CELLULAR_NETWORK_FAILED_REASON[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_CELLULAR_NETWORK_FAILED_REASON[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_cellular_network_radio_type.go
+++ b/pkg/dialects/common/enum_cellular_network_radio_type.go
@@ -36,28 +36,28 @@ var values_CELLULAR_NETWORK_RADIO_TYPE = map[string]CELLULAR_NETWORK_RADIO_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CELLULAR_NETWORK_RADIO_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_CELLULAR_NETWORK_RADIO_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_CELLULAR_NETWORK_RADIO_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CELLULAR_NETWORK_RADIO_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_CELLULAR_NETWORK_RADIO_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_CELLULAR_NETWORK_RADIO_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = CELLULAR_NETWORK_RADIO_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CELLULAR_NETWORK_RADIO_TYPE) String() string {
-	name, ok := labels_CELLULAR_NETWORK_RADIO_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_CELLULAR_NETWORK_RADIO_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_cellular_status_flag.go
+++ b/pkg/dialects/common/enum_cellular_status_flag.go
@@ -73,28 +73,28 @@ var values_CELLULAR_STATUS_FLAG = map[string]CELLULAR_STATUS_FLAG{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e CELLULAR_STATUS_FLAG) MarshalText() ([]byte, error) {
-	name, ok := labels_CELLULAR_STATUS_FLAG[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_CELLULAR_STATUS_FLAG[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *CELLULAR_STATUS_FLAG) UnmarshalText(text []byte) error {
-	value, ok := values_CELLULAR_STATUS_FLAG[string(text)]
-	if !ok {
+	if value, ok := values_CELLULAR_STATUS_FLAG[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = CELLULAR_STATUS_FLAG(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e CELLULAR_STATUS_FLAG) String() string {
-	name, ok := labels_CELLULAR_STATUS_FLAG[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_CELLULAR_STATUS_FLAG[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_comp_metadata_type.go
+++ b/pkg/dialects/common/enum_comp_metadata_type.go
@@ -45,28 +45,28 @@ var values_COMP_METADATA_TYPE = map[string]COMP_METADATA_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e COMP_METADATA_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_COMP_METADATA_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_COMP_METADATA_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *COMP_METADATA_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_COMP_METADATA_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_COMP_METADATA_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = COMP_METADATA_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e COMP_METADATA_TYPE) String() string {
-	name, ok := labels_COMP_METADATA_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_COMP_METADATA_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_esc_connection_type.go
+++ b/pkg/dialects/common/enum_esc_connection_type.go
@@ -45,28 +45,28 @@ var values_ESC_CONNECTION_TYPE = map[string]ESC_CONNECTION_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ESC_CONNECTION_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_ESC_CONNECTION_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_ESC_CONNECTION_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ESC_CONNECTION_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_ESC_CONNECTION_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_ESC_CONNECTION_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = ESC_CONNECTION_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ESC_CONNECTION_TYPE) String() string {
-	name, ok := labels_ESC_CONNECTION_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_ESC_CONNECTION_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_esc_failure_flags.go
+++ b/pkg/dialects/common/enum_esc_failure_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -53,6 +54,9 @@ var values_ESC_FAILURE_FLAGS = map[string]ESC_FAILURE_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ESC_FAILURE_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 8; i++ {
 		mask := ESC_FAILURE_FLAGS(1 << i)
@@ -70,6 +74,8 @@ func (e *ESC_FAILURE_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_ESC_FAILURE_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= ESC_FAILURE_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_estimator_status_flags.go
+++ b/pkg/dialects/common/enum_estimator_status_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -69,6 +70,9 @@ var values_ESTIMATOR_STATUS_FLAGS = map[string]ESTIMATOR_STATUS_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ESTIMATOR_STATUS_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 12; i++ {
 		mask := ESTIMATOR_STATUS_FLAGS(1 << i)
@@ -86,6 +90,8 @@ func (e *ESTIMATOR_STATUS_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_ESTIMATOR_STATUS_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= ESTIMATOR_STATUS_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_failure_type.go
+++ b/pkg/dialects/common/enum_failure_type.go
@@ -53,28 +53,28 @@ var values_FAILURE_TYPE = map[string]FAILURE_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e FAILURE_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_FAILURE_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_FAILURE_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *FAILURE_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_FAILURE_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_FAILURE_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = FAILURE_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e FAILURE_TYPE) String() string {
-	name, ok := labels_FAILURE_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_FAILURE_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_failure_unit.go
+++ b/pkg/dialects/common/enum_failure_unit.go
@@ -66,28 +66,28 @@ var values_FAILURE_UNIT = map[string]FAILURE_UNIT{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e FAILURE_UNIT) MarshalText() ([]byte, error) {
-	name, ok := labels_FAILURE_UNIT[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_FAILURE_UNIT[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *FAILURE_UNIT) UnmarshalText(text []byte) error {
-	value, ok := values_FAILURE_UNIT[string(text)]
-	if !ok {
+	if value, ok := values_FAILURE_UNIT[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = FAILURE_UNIT(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e FAILURE_UNIT) String() string {
-	name, ok := labels_FAILURE_UNIT[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_FAILURE_UNIT[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_fence_action.go
+++ b/pkg/dialects/common/enum_fence_action.go
@@ -53,28 +53,28 @@ var values_FENCE_ACTION = map[string]FENCE_ACTION{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e FENCE_ACTION) MarshalText() ([]byte, error) {
-	name, ok := labels_FENCE_ACTION[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_FENCE_ACTION[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *FENCE_ACTION) UnmarshalText(text []byte) error {
-	value, ok := values_FENCE_ACTION[string(text)]
-	if !ok {
+	if value, ok := values_FENCE_ACTION[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = FENCE_ACTION(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e FENCE_ACTION) String() string {
-	name, ok := labels_FENCE_ACTION[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_FENCE_ACTION[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_fence_breach.go
+++ b/pkg/dialects/common/enum_fence_breach.go
@@ -36,28 +36,28 @@ var values_FENCE_BREACH = map[string]FENCE_BREACH{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e FENCE_BREACH) MarshalText() ([]byte, error) {
-	name, ok := labels_FENCE_BREACH[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_FENCE_BREACH[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *FENCE_BREACH) UnmarshalText(text []byte) error {
-	value, ok := values_FENCE_BREACH[string(text)]
-	if !ok {
+	if value, ok := values_FENCE_BREACH[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = FENCE_BREACH(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e FENCE_BREACH) String() string {
-	name, ok := labels_FENCE_BREACH[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_FENCE_BREACH[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_fence_mitigate.go
+++ b/pkg/dialects/common/enum_fence_mitigate.go
@@ -33,28 +33,28 @@ var values_FENCE_MITIGATE = map[string]FENCE_MITIGATE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e FENCE_MITIGATE) MarshalText() ([]byte, error) {
-	name, ok := labels_FENCE_MITIGATE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_FENCE_MITIGATE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *FENCE_MITIGATE) UnmarshalText(text []byte) error {
-	value, ok := values_FENCE_MITIGATE[string(text)]
-	if !ok {
+	if value, ok := values_FENCE_MITIGATE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = FENCE_MITIGATE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e FENCE_MITIGATE) String() string {
-	name, ok := labels_FENCE_MITIGATE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_FENCE_MITIGATE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_firmware_version_type.go
+++ b/pkg/dialects/common/enum_firmware_version_type.go
@@ -41,28 +41,28 @@ var values_FIRMWARE_VERSION_TYPE = map[string]FIRMWARE_VERSION_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e FIRMWARE_VERSION_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_FIRMWARE_VERSION_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_FIRMWARE_VERSION_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *FIRMWARE_VERSION_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_FIRMWARE_VERSION_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_FIRMWARE_VERSION_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = FIRMWARE_VERSION_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e FIRMWARE_VERSION_TYPE) String() string {
-	name, ok := labels_FIRMWARE_VERSION_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_FIRMWARE_VERSION_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_gimbal_device_cap_flags.go
+++ b/pkg/dialects/common/enum_gimbal_device_cap_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -77,6 +78,9 @@ var values_GIMBAL_DEVICE_CAP_FLAGS = map[string]GIMBAL_DEVICE_CAP_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GIMBAL_DEVICE_CAP_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 14; i++ {
 		mask := GIMBAL_DEVICE_CAP_FLAGS(1 << i)
@@ -94,6 +98,8 @@ func (e *GIMBAL_DEVICE_CAP_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_GIMBAL_DEVICE_CAP_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= GIMBAL_DEVICE_CAP_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_gimbal_device_error_flags.go
+++ b/pkg/dialects/common/enum_gimbal_device_error_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -61,6 +62,9 @@ var values_GIMBAL_DEVICE_ERROR_FLAGS = map[string]GIMBAL_DEVICE_ERROR_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GIMBAL_DEVICE_ERROR_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 10; i++ {
 		mask := GIMBAL_DEVICE_ERROR_FLAGS(1 << i)
@@ -78,6 +82,8 @@ func (e *GIMBAL_DEVICE_ERROR_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_GIMBAL_DEVICE_ERROR_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= GIMBAL_DEVICE_ERROR_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_gimbal_device_flags.go
+++ b/pkg/dialects/common/enum_gimbal_device_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -61,6 +62,9 @@ var values_GIMBAL_DEVICE_FLAGS = map[string]GIMBAL_DEVICE_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GIMBAL_DEVICE_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 10; i++ {
 		mask := GIMBAL_DEVICE_FLAGS(1 << i)
@@ -78,6 +82,8 @@ func (e *GIMBAL_DEVICE_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_GIMBAL_DEVICE_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= GIMBAL_DEVICE_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_gimbal_manager_cap_flags.go
+++ b/pkg/dialects/common/enum_gimbal_manager_cap_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -85,6 +86,9 @@ var values_GIMBAL_MANAGER_CAP_FLAGS = map[string]GIMBAL_MANAGER_CAP_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GIMBAL_MANAGER_CAP_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 16; i++ {
 		mask := GIMBAL_MANAGER_CAP_FLAGS(1 << i)
@@ -102,6 +106,8 @@ func (e *GIMBAL_MANAGER_CAP_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_GIMBAL_MANAGER_CAP_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= GIMBAL_MANAGER_CAP_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_gimbal_manager_flags.go
+++ b/pkg/dialects/common/enum_gimbal_manager_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -61,6 +62,9 @@ var values_GIMBAL_MANAGER_FLAGS = map[string]GIMBAL_MANAGER_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GIMBAL_MANAGER_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 10; i++ {
 		mask := GIMBAL_MANAGER_FLAGS(1 << i)
@@ -78,6 +82,8 @@ func (e *GIMBAL_MANAGER_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_GIMBAL_MANAGER_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= GIMBAL_MANAGER_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_gps_fix_type.go
+++ b/pkg/dialects/common/enum_gps_fix_type.go
@@ -57,28 +57,28 @@ var values_GPS_FIX_TYPE = map[string]GPS_FIX_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GPS_FIX_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_GPS_FIX_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GPS_FIX_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GPS_FIX_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_GPS_FIX_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_GPS_FIX_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GPS_FIX_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GPS_FIX_TYPE) String() string {
-	name, ok := labels_GPS_FIX_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GPS_FIX_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_gps_input_ignore_flags.go
+++ b/pkg/dialects/common/enum_gps_input_ignore_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -52,6 +53,9 @@ var values_GPS_INPUT_IGNORE_FLAGS = map[string]GPS_INPUT_IGNORE_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GPS_INPUT_IGNORE_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 8; i++ {
 		mask := GPS_INPUT_IGNORE_FLAGS(1 << i)
@@ -69,6 +73,8 @@ func (e *GPS_INPUT_IGNORE_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_GPS_INPUT_IGNORE_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= GPS_INPUT_IGNORE_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_gripper_actions.go
+++ b/pkg/dialects/common/enum_gripper_actions.go
@@ -29,28 +29,28 @@ var values_GRIPPER_ACTIONS = map[string]GRIPPER_ACTIONS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e GRIPPER_ACTIONS) MarshalText() ([]byte, error) {
-	name, ok := labels_GRIPPER_ACTIONS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_GRIPPER_ACTIONS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *GRIPPER_ACTIONS) UnmarshalText(text []byte) error {
-	value, ok := values_GRIPPER_ACTIONS[string(text)]
-	if !ok {
+	if value, ok := values_GRIPPER_ACTIONS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = GRIPPER_ACTIONS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e GRIPPER_ACTIONS) String() string {
-	name, ok := labels_GRIPPER_ACTIONS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_GRIPPER_ACTIONS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_highres_imu_updated_flags.go
+++ b/pkg/dialects/common/enum_highres_imu_updated_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -81,6 +82,9 @@ var values_HIGHRES_IMU_UPDATED_FLAGS = map[string]HIGHRES_IMU_UPDATED_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e HIGHRES_IMU_UPDATED_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 15; i++ {
 		mask := HIGHRES_IMU_UPDATED_FLAGS(1 << i)
@@ -98,6 +102,8 @@ func (e *HIGHRES_IMU_UPDATED_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_HIGHRES_IMU_UPDATED_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= HIGHRES_IMU_UPDATED_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_hil_sensor_updated_flags.go
+++ b/pkg/dialects/common/enum_hil_sensor_updated_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -81,6 +82,9 @@ var values_HIL_SENSOR_UPDATED_FLAGS = map[string]HIL_SENSOR_UPDATED_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e HIL_SENSOR_UPDATED_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 15; i++ {
 		mask := HIL_SENSOR_UPDATED_FLAGS(1 << i)
@@ -98,6 +102,8 @@ func (e *HIL_SENSOR_UPDATED_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_HIL_SENSOR_UPDATED_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= HIL_SENSOR_UPDATED_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_hl_failure_flag.go
+++ b/pkg/dialects/common/enum_hl_failure_flag.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -77,6 +78,9 @@ var values_HL_FAILURE_FLAG = map[string]HL_FAILURE_FLAG{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e HL_FAILURE_FLAG) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 14; i++ {
 		mask := HL_FAILURE_FLAG(1 << i)
@@ -94,6 +98,8 @@ func (e *HL_FAILURE_FLAG) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_HL_FAILURE_FLAG[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= HL_FAILURE_FLAG(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_landing_target_type.go
+++ b/pkg/dialects/common/enum_landing_target_type.go
@@ -37,28 +37,28 @@ var values_LANDING_TARGET_TYPE = map[string]LANDING_TARGET_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e LANDING_TARGET_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_LANDING_TARGET_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_LANDING_TARGET_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *LANDING_TARGET_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_LANDING_TARGET_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_LANDING_TARGET_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = LANDING_TARGET_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e LANDING_TARGET_TYPE) String() string {
-	name, ok := labels_LANDING_TARGET_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_LANDING_TARGET_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mag_cal_status.go
+++ b/pkg/dialects/common/enum_mag_cal_status.go
@@ -44,28 +44,28 @@ var values_MAG_CAL_STATUS = map[string]MAG_CAL_STATUS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAG_CAL_STATUS) MarshalText() ([]byte, error) {
-	name, ok := labels_MAG_CAL_STATUS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAG_CAL_STATUS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAG_CAL_STATUS) UnmarshalText(text []byte) error {
-	value, ok := values_MAG_CAL_STATUS[string(text)]
-	if !ok {
+	if value, ok := values_MAG_CAL_STATUS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAG_CAL_STATUS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAG_CAL_STATUS) String() string {
-	name, ok := labels_MAG_CAL_STATUS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAG_CAL_STATUS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_arm_auth_denied_reason.go
+++ b/pkg/dialects/common/enum_mav_arm_auth_denied_reason.go
@@ -44,28 +44,28 @@ var values_MAV_ARM_AUTH_DENIED_REASON = map[string]MAV_ARM_AUTH_DENIED_REASON{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ARM_AUTH_DENIED_REASON) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ARM_AUTH_DENIED_REASON[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ARM_AUTH_DENIED_REASON[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ARM_AUTH_DENIED_REASON) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ARM_AUTH_DENIED_REASON[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ARM_AUTH_DENIED_REASON[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ARM_AUTH_DENIED_REASON(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ARM_AUTH_DENIED_REASON) String() string {
-	name, ok := labels_MAV_ARM_AUTH_DENIED_REASON[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ARM_AUTH_DENIED_REASON[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_battery_charge_state.go
+++ b/pkg/dialects/common/enum_mav_battery_charge_state.go
@@ -53,28 +53,28 @@ var values_MAV_BATTERY_CHARGE_STATE = map[string]MAV_BATTERY_CHARGE_STATE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_BATTERY_CHARGE_STATE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_BATTERY_CHARGE_STATE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_BATTERY_CHARGE_STATE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_BATTERY_CHARGE_STATE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_BATTERY_CHARGE_STATE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_BATTERY_CHARGE_STATE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_BATTERY_CHARGE_STATE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_BATTERY_CHARGE_STATE) String() string {
-	name, ok := labels_MAV_BATTERY_CHARGE_STATE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_BATTERY_CHARGE_STATE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_battery_fault.go
+++ b/pkg/dialects/common/enum_mav_battery_fault.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -57,6 +58,9 @@ var values_MAV_BATTERY_FAULT = map[string]MAV_BATTERY_FAULT{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_BATTERY_FAULT) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 9; i++ {
 		mask := MAV_BATTERY_FAULT(1 << i)
@@ -74,6 +78,8 @@ func (e *MAV_BATTERY_FAULT) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_MAV_BATTERY_FAULT[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_BATTERY_FAULT(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_mav_battery_function.go
+++ b/pkg/dialects/common/enum_mav_battery_function.go
@@ -41,28 +41,28 @@ var values_MAV_BATTERY_FUNCTION = map[string]MAV_BATTERY_FUNCTION{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_BATTERY_FUNCTION) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_BATTERY_FUNCTION[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_BATTERY_FUNCTION[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_BATTERY_FUNCTION) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_BATTERY_FUNCTION[string(text)]
-	if !ok {
+	if value, ok := values_MAV_BATTERY_FUNCTION[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_BATTERY_FUNCTION(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_BATTERY_FUNCTION) String() string {
-	name, ok := labels_MAV_BATTERY_FUNCTION[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_BATTERY_FUNCTION[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_battery_mode.go
+++ b/pkg/dialects/common/enum_mav_battery_mode.go
@@ -33,28 +33,28 @@ var values_MAV_BATTERY_MODE = map[string]MAV_BATTERY_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_BATTERY_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_BATTERY_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_BATTERY_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_BATTERY_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_BATTERY_MODE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_BATTERY_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_BATTERY_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_BATTERY_MODE) String() string {
-	name, ok := labels_MAV_BATTERY_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_BATTERY_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_battery_type.go
+++ b/pkg/dialects/common/enum_mav_battery_type.go
@@ -41,28 +41,28 @@ var values_MAV_BATTERY_TYPE = map[string]MAV_BATTERY_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_BATTERY_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_BATTERY_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_BATTERY_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_BATTERY_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_BATTERY_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_BATTERY_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_BATTERY_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_BATTERY_TYPE) String() string {
-	name, ok := labels_MAV_BATTERY_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_BATTERY_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_cmd.go
+++ b/pkg/dialects/common/enum_mav_cmd.go
@@ -706,28 +706,28 @@ var values_MAV_CMD = map[string]MAV_CMD{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_CMD[string(text)]
-	if !ok {
+	if value, ok := values_MAV_CMD[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_CMD(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD) String() string {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_collision_action.go
+++ b/pkg/dialects/common/enum_mav_collision_action.go
@@ -49,28 +49,28 @@ var values_MAV_COLLISION_ACTION = map[string]MAV_COLLISION_ACTION{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_COLLISION_ACTION) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_COLLISION_ACTION[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_COLLISION_ACTION[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_COLLISION_ACTION) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_COLLISION_ACTION[string(text)]
-	if !ok {
+	if value, ok := values_MAV_COLLISION_ACTION[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_COLLISION_ACTION(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_COLLISION_ACTION) String() string {
-	name, ok := labels_MAV_COLLISION_ACTION[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_COLLISION_ACTION[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_collision_src.go
+++ b/pkg/dialects/common/enum_mav_collision_src.go
@@ -29,28 +29,28 @@ var values_MAV_COLLISION_SRC = map[string]MAV_COLLISION_SRC{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_COLLISION_SRC) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_COLLISION_SRC[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_COLLISION_SRC[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_COLLISION_SRC) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_COLLISION_SRC[string(text)]
-	if !ok {
+	if value, ok := values_MAV_COLLISION_SRC[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_COLLISION_SRC(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_COLLISION_SRC) String() string {
-	name, ok := labels_MAV_COLLISION_SRC[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_COLLISION_SRC[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_collision_threat_level.go
+++ b/pkg/dialects/common/enum_mav_collision_threat_level.go
@@ -33,28 +33,28 @@ var values_MAV_COLLISION_THREAT_LEVEL = map[string]MAV_COLLISION_THREAT_LEVEL{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_COLLISION_THREAT_LEVEL) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_COLLISION_THREAT_LEVEL[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_COLLISION_THREAT_LEVEL[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_COLLISION_THREAT_LEVEL) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_COLLISION_THREAT_LEVEL[string(text)]
-	if !ok {
+	if value, ok := values_MAV_COLLISION_THREAT_LEVEL[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_COLLISION_THREAT_LEVEL(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_COLLISION_THREAT_LEVEL) String() string {
-	name, ok := labels_MAV_COLLISION_THREAT_LEVEL[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_COLLISION_THREAT_LEVEL[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_data_stream.go
+++ b/pkg/dialects/common/enum_mav_data_stream.go
@@ -59,28 +59,28 @@ var values_MAV_DATA_STREAM = map[string]MAV_DATA_STREAM{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_DATA_STREAM) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_DATA_STREAM[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_DATA_STREAM[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_DATA_STREAM) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_DATA_STREAM[string(text)]
-	if !ok {
+	if value, ok := values_MAV_DATA_STREAM[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_DATA_STREAM(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_DATA_STREAM) String() string {
-	name, ok := labels_MAV_DATA_STREAM[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_DATA_STREAM[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_distance_sensor.go
+++ b/pkg/dialects/common/enum_mav_distance_sensor.go
@@ -41,28 +41,28 @@ var values_MAV_DISTANCE_SENSOR = map[string]MAV_DISTANCE_SENSOR{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_DISTANCE_SENSOR) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_DISTANCE_SENSOR[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_DISTANCE_SENSOR[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_DISTANCE_SENSOR) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_DISTANCE_SENSOR[string(text)]
-	if !ok {
+	if value, ok := values_MAV_DISTANCE_SENSOR[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_DISTANCE_SENSOR(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_DISTANCE_SENSOR) String() string {
-	name, ok := labels_MAV_DISTANCE_SENSOR[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_DISTANCE_SENSOR[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_do_reposition_flags.go
+++ b/pkg/dialects/common/enum_mav_do_reposition_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -25,6 +26,9 @@ var values_MAV_DO_REPOSITION_FLAGS = map[string]MAV_DO_REPOSITION_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_DO_REPOSITION_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 1; i++ {
 		mask := MAV_DO_REPOSITION_FLAGS(1 << i)
@@ -42,6 +46,8 @@ func (e *MAV_DO_REPOSITION_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_MAV_DO_REPOSITION_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_DO_REPOSITION_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_mav_estimator_type.go
+++ b/pkg/dialects/common/enum_mav_estimator_type.go
@@ -57,28 +57,28 @@ var values_MAV_ESTIMATOR_TYPE = map[string]MAV_ESTIMATOR_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ESTIMATOR_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ESTIMATOR_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ESTIMATOR_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ESTIMATOR_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ESTIMATOR_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ESTIMATOR_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ESTIMATOR_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ESTIMATOR_TYPE) String() string {
-	name, ok := labels_MAV_ESTIMATOR_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ESTIMATOR_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_event_current_sequence_flags.go
+++ b/pkg/dialects/common/enum_mav_event_current_sequence_flags.go
@@ -25,28 +25,28 @@ var values_MAV_EVENT_CURRENT_SEQUENCE_FLAGS = map[string]MAV_EVENT_CURRENT_SEQUE
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_EVENT_CURRENT_SEQUENCE_FLAGS) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_EVENT_CURRENT_SEQUENCE_FLAGS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_EVENT_CURRENT_SEQUENCE_FLAGS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_EVENT_CURRENT_SEQUENCE_FLAGS) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_EVENT_CURRENT_SEQUENCE_FLAGS[string(text)]
-	if !ok {
+	if value, ok := values_MAV_EVENT_CURRENT_SEQUENCE_FLAGS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_EVENT_CURRENT_SEQUENCE_FLAGS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_EVENT_CURRENT_SEQUENCE_FLAGS) String() string {
-	name, ok := labels_MAV_EVENT_CURRENT_SEQUENCE_FLAGS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_EVENT_CURRENT_SEQUENCE_FLAGS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_event_error_reason.go
+++ b/pkg/dialects/common/enum_mav_event_error_reason.go
@@ -25,28 +25,28 @@ var values_MAV_EVENT_ERROR_REASON = map[string]MAV_EVENT_ERROR_REASON{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_EVENT_ERROR_REASON) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_EVENT_ERROR_REASON[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_EVENT_ERROR_REASON[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_EVENT_ERROR_REASON) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_EVENT_ERROR_REASON[string(text)]
-	if !ok {
+	if value, ok := values_MAV_EVENT_ERROR_REASON[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_EVENT_ERROR_REASON(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_EVENT_ERROR_REASON) String() string {
-	name, ok := labels_MAV_EVENT_ERROR_REASON[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_EVENT_ERROR_REASON[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_frame.go
+++ b/pkg/dialects/common/enum_mav_frame.go
@@ -122,28 +122,28 @@ var values_MAV_FRAME = map[string]MAV_FRAME{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_FRAME) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_FRAME[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_FRAME[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_FRAME) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_FRAME[string(text)]
-	if !ok {
+	if value, ok := values_MAV_FRAME[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_FRAME(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_FRAME) String() string {
-	name, ok := labels_MAV_FRAME[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_FRAME[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_ftp_err.go
+++ b/pkg/dialects/common/enum_mav_ftp_err.go
@@ -66,28 +66,28 @@ var values_MAV_FTP_ERR = map[string]MAV_FTP_ERR{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_FTP_ERR) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_FTP_ERR[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_FTP_ERR[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_FTP_ERR) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_FTP_ERR[string(text)]
-	if !ok {
+	if value, ok := values_MAV_FTP_ERR[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_FTP_ERR(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_FTP_ERR) String() string {
-	name, ok := labels_MAV_FTP_ERR[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_FTP_ERR[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_ftp_opcode.go
+++ b/pkg/dialects/common/enum_mav_ftp_opcode.go
@@ -93,28 +93,28 @@ var values_MAV_FTP_OPCODE = map[string]MAV_FTP_OPCODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_FTP_OPCODE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_FTP_OPCODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_FTP_OPCODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_FTP_OPCODE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_FTP_OPCODE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_FTP_OPCODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_FTP_OPCODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_FTP_OPCODE) String() string {
-	name, ok := labels_MAV_FTP_OPCODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_FTP_OPCODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_generator_status_flag.go
+++ b/pkg/dialects/common/enum_mav_generator_status_flag.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -113,6 +114,9 @@ var values_MAV_GENERATOR_STATUS_FLAG = map[string]MAV_GENERATOR_STATUS_FLAG{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_GENERATOR_STATUS_FLAG) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 23; i++ {
 		mask := MAV_GENERATOR_STATUS_FLAG(1 << i)
@@ -130,6 +134,8 @@ func (e *MAV_GENERATOR_STATUS_FLAG) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_MAV_GENERATOR_STATUS_FLAG[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_GENERATOR_STATUS_FLAG(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_mav_goto.go
+++ b/pkg/dialects/common/enum_mav_goto.go
@@ -37,28 +37,28 @@ var values_MAV_GOTO = map[string]MAV_GOTO{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_GOTO) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_GOTO[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_GOTO[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_GOTO) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_GOTO[string(text)]
-	if !ok {
+	if value, ok := values_MAV_GOTO[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_GOTO(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_GOTO) String() string {
-	name, ok := labels_MAV_GOTO[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_GOTO[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_landed_state.go
+++ b/pkg/dialects/common/enum_mav_landed_state.go
@@ -41,28 +41,28 @@ var values_MAV_LANDED_STATE = map[string]MAV_LANDED_STATE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_LANDED_STATE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_LANDED_STATE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_LANDED_STATE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_LANDED_STATE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_LANDED_STATE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_LANDED_STATE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_LANDED_STATE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_LANDED_STATE) String() string {
-	name, ok := labels_MAV_LANDED_STATE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_LANDED_STATE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_mission_result.go
+++ b/pkg/dialects/common/enum_mav_mission_result.go
@@ -85,28 +85,28 @@ var values_MAV_MISSION_RESULT = map[string]MAV_MISSION_RESULT{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MISSION_RESULT) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_MISSION_RESULT[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_MISSION_RESULT[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_MISSION_RESULT) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_MISSION_RESULT[string(text)]
-	if !ok {
+	if value, ok := values_MAV_MISSION_RESULT[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_MISSION_RESULT(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_MISSION_RESULT) String() string {
-	name, ok := labels_MAV_MISSION_RESULT[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_MISSION_RESULT[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_mission_type.go
+++ b/pkg/dialects/common/enum_mav_mission_type.go
@@ -37,28 +37,28 @@ var values_MAV_MISSION_TYPE = map[string]MAV_MISSION_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MISSION_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_MISSION_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_MISSION_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_MISSION_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_MISSION_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_MISSION_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_MISSION_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_MISSION_TYPE) String() string {
-	name, ok := labels_MAV_MISSION_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_MISSION_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_mode.go
+++ b/pkg/dialects/common/enum_mav_mode.go
@@ -66,28 +66,28 @@ var values_MAV_MODE = map[string]MAV_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_MODE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_MODE) String() string {
-	name, ok := labels_MAV_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_mount_mode.go
+++ b/pkg/dialects/common/enum_mav_mount_mode.go
@@ -49,28 +49,28 @@ var values_MAV_MOUNT_MODE = map[string]MAV_MOUNT_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MOUNT_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_MOUNT_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_MOUNT_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_MOUNT_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_MOUNT_MODE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_MOUNT_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_MOUNT_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_MOUNT_MODE) String() string {
-	name, ok := labels_MAV_MOUNT_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_MOUNT_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_arm_status.go
+++ b/pkg/dialects/common/enum_mav_odid_arm_status.go
@@ -28,28 +28,28 @@ var values_MAV_ODID_ARM_STATUS = map[string]MAV_ODID_ARM_STATUS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_ARM_STATUS) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_ARM_STATUS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_ARM_STATUS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_ARM_STATUS) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_ARM_STATUS[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_ARM_STATUS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_ARM_STATUS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_ARM_STATUS) String() string {
-	name, ok := labels_MAV_ODID_ARM_STATUS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_ARM_STATUS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_auth_type.go
+++ b/pkg/dialects/common/enum_mav_odid_auth_type.go
@@ -44,28 +44,28 @@ var values_MAV_ODID_AUTH_TYPE = map[string]MAV_ODID_AUTH_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_AUTH_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_AUTH_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_AUTH_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_AUTH_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_AUTH_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_AUTH_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_AUTH_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_AUTH_TYPE) String() string {
-	name, ok := labels_MAV_ODID_AUTH_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_AUTH_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_category_eu.go
+++ b/pkg/dialects/common/enum_mav_odid_category_eu.go
@@ -36,28 +36,28 @@ var values_MAV_ODID_CATEGORY_EU = map[string]MAV_ODID_CATEGORY_EU{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_CATEGORY_EU) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_CATEGORY_EU[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_CATEGORY_EU[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_CATEGORY_EU) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_CATEGORY_EU[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_CATEGORY_EU[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_CATEGORY_EU(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_CATEGORY_EU) String() string {
-	name, ok := labels_MAV_ODID_CATEGORY_EU[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_CATEGORY_EU[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_class_eu.go
+++ b/pkg/dialects/common/enum_mav_odid_class_eu.go
@@ -52,28 +52,28 @@ var values_MAV_ODID_CLASS_EU = map[string]MAV_ODID_CLASS_EU{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_CLASS_EU) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_CLASS_EU[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_CLASS_EU[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_CLASS_EU) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_CLASS_EU[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_CLASS_EU[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_CLASS_EU(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_CLASS_EU) String() string {
-	name, ok := labels_MAV_ODID_CLASS_EU[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_CLASS_EU[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_classification_type.go
+++ b/pkg/dialects/common/enum_mav_odid_classification_type.go
@@ -28,28 +28,28 @@ var values_MAV_ODID_CLASSIFICATION_TYPE = map[string]MAV_ODID_CLASSIFICATION_TYP
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_CLASSIFICATION_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_CLASSIFICATION_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_CLASSIFICATION_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_CLASSIFICATION_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_CLASSIFICATION_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_CLASSIFICATION_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_CLASSIFICATION_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_CLASSIFICATION_TYPE) String() string {
-	name, ok := labels_MAV_ODID_CLASSIFICATION_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_CLASSIFICATION_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_desc_type.go
+++ b/pkg/dialects/common/enum_mav_odid_desc_type.go
@@ -32,28 +32,28 @@ var values_MAV_ODID_DESC_TYPE = map[string]MAV_ODID_DESC_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_DESC_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_DESC_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_DESC_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_DESC_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_DESC_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_DESC_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_DESC_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_DESC_TYPE) String() string {
-	name, ok := labels_MAV_ODID_DESC_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_DESC_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_height_ref.go
+++ b/pkg/dialects/common/enum_mav_odid_height_ref.go
@@ -28,28 +28,28 @@ var values_MAV_ODID_HEIGHT_REF = map[string]MAV_ODID_HEIGHT_REF{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_HEIGHT_REF) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_HEIGHT_REF[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_HEIGHT_REF[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_HEIGHT_REF) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_HEIGHT_REF[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_HEIGHT_REF[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_HEIGHT_REF(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_HEIGHT_REF) String() string {
-	name, ok := labels_MAV_ODID_HEIGHT_REF[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_HEIGHT_REF[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_hor_acc.go
+++ b/pkg/dialects/common/enum_mav_odid_hor_acc.go
@@ -72,28 +72,28 @@ var values_MAV_ODID_HOR_ACC = map[string]MAV_ODID_HOR_ACC{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_HOR_ACC) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_HOR_ACC[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_HOR_ACC[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_HOR_ACC) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_HOR_ACC[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_HOR_ACC[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_HOR_ACC(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_HOR_ACC) String() string {
-	name, ok := labels_MAV_ODID_HOR_ACC[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_HOR_ACC[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_id_type.go
+++ b/pkg/dialects/common/enum_mav_odid_id_type.go
@@ -40,28 +40,28 @@ var values_MAV_ODID_ID_TYPE = map[string]MAV_ODID_ID_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_ID_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_ID_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_ID_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_ID_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_ID_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_ID_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_ID_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_ID_TYPE) String() string {
-	name, ok := labels_MAV_ODID_ID_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_ID_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_operator_id_type.go
+++ b/pkg/dialects/common/enum_mav_odid_operator_id_type.go
@@ -24,28 +24,28 @@ var values_MAV_ODID_OPERATOR_ID_TYPE = map[string]MAV_ODID_OPERATOR_ID_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_OPERATOR_ID_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_OPERATOR_ID_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_OPERATOR_ID_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_OPERATOR_ID_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_OPERATOR_ID_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_OPERATOR_ID_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_OPERATOR_ID_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_OPERATOR_ID_TYPE) String() string {
-	name, ok := labels_MAV_ODID_OPERATOR_ID_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_OPERATOR_ID_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_operator_location_type.go
+++ b/pkg/dialects/common/enum_mav_odid_operator_location_type.go
@@ -32,28 +32,28 @@ var values_MAV_ODID_OPERATOR_LOCATION_TYPE = map[string]MAV_ODID_OPERATOR_LOCATI
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_OPERATOR_LOCATION_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_OPERATOR_LOCATION_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_OPERATOR_LOCATION_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_OPERATOR_LOCATION_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_OPERATOR_LOCATION_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_OPERATOR_LOCATION_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_OPERATOR_LOCATION_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_OPERATOR_LOCATION_TYPE) String() string {
-	name, ok := labels_MAV_ODID_OPERATOR_LOCATION_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_OPERATOR_LOCATION_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_speed_acc.go
+++ b/pkg/dialects/common/enum_mav_odid_speed_acc.go
@@ -40,28 +40,28 @@ var values_MAV_ODID_SPEED_ACC = map[string]MAV_ODID_SPEED_ACC{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_SPEED_ACC) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_SPEED_ACC[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_SPEED_ACC[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_SPEED_ACC) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_SPEED_ACC[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_SPEED_ACC[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_SPEED_ACC(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_SPEED_ACC) String() string {
-	name, ok := labels_MAV_ODID_SPEED_ACC[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_SPEED_ACC[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_status.go
+++ b/pkg/dialects/common/enum_mav_odid_status.go
@@ -40,28 +40,28 @@ var values_MAV_ODID_STATUS = map[string]MAV_ODID_STATUS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_STATUS) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_STATUS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_STATUS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_STATUS) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_STATUS[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_STATUS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_STATUS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_STATUS) String() string {
-	name, ok := labels_MAV_ODID_STATUS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_STATUS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_time_acc.go
+++ b/pkg/dialects/common/enum_mav_odid_time_acc.go
@@ -84,28 +84,28 @@ var values_MAV_ODID_TIME_ACC = map[string]MAV_ODID_TIME_ACC{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_TIME_ACC) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_TIME_ACC[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_TIME_ACC[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_TIME_ACC) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_TIME_ACC[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_TIME_ACC[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_TIME_ACC(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_TIME_ACC) String() string {
-	name, ok := labels_MAV_ODID_TIME_ACC[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_TIME_ACC[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_ua_type.go
+++ b/pkg/dialects/common/enum_mav_odid_ua_type.go
@@ -84,28 +84,28 @@ var values_MAV_ODID_UA_TYPE = map[string]MAV_ODID_UA_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_UA_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_UA_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_UA_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_UA_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_UA_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_UA_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_UA_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_UA_TYPE) String() string {
-	name, ok := labels_MAV_ODID_UA_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_UA_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_odid_ver_acc.go
+++ b/pkg/dialects/common/enum_mav_odid_ver_acc.go
@@ -48,28 +48,28 @@ var values_MAV_ODID_VER_ACC = map[string]MAV_ODID_VER_ACC{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ODID_VER_ACC) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ODID_VER_ACC[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ODID_VER_ACC[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ODID_VER_ACC) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ODID_VER_ACC[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ODID_VER_ACC[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ODID_VER_ACC(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ODID_VER_ACC) String() string {
-	name, ok := labels_MAV_ODID_VER_ACC[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ODID_VER_ACC[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_param_ext_type.go
+++ b/pkg/dialects/common/enum_mav_param_ext_type.go
@@ -65,28 +65,28 @@ var values_MAV_PARAM_EXT_TYPE = map[string]MAV_PARAM_EXT_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_PARAM_EXT_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_PARAM_EXT_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_PARAM_EXT_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_PARAM_EXT_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_PARAM_EXT_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_PARAM_EXT_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_PARAM_EXT_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_PARAM_EXT_TYPE) String() string {
-	name, ok := labels_MAV_PARAM_EXT_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_PARAM_EXT_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_param_type.go
+++ b/pkg/dialects/common/enum_mav_param_type.go
@@ -61,28 +61,28 @@ var values_MAV_PARAM_TYPE = map[string]MAV_PARAM_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_PARAM_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_PARAM_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_PARAM_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_PARAM_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_PARAM_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_PARAM_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_PARAM_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_PARAM_TYPE) String() string {
-	name, ok := labels_MAV_PARAM_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_PARAM_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_power_status.go
+++ b/pkg/dialects/common/enum_mav_power_status.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -45,6 +46,9 @@ var values_MAV_POWER_STATUS = map[string]MAV_POWER_STATUS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_POWER_STATUS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 6; i++ {
 		mask := MAV_POWER_STATUS(1 << i)
@@ -62,6 +66,8 @@ func (e *MAV_POWER_STATUS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_MAV_POWER_STATUS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_POWER_STATUS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_mav_protocol_capability.go
+++ b/pkg/dialects/common/enum_mav_protocol_capability.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -97,6 +98,9 @@ var values_MAV_PROTOCOL_CAPABILITY = map[string]MAV_PROTOCOL_CAPABILITY{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_PROTOCOL_CAPABILITY) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 18; i++ {
 		mask := MAV_PROTOCOL_CAPABILITY(1 << i)
@@ -114,6 +118,8 @@ func (e *MAV_PROTOCOL_CAPABILITY) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_MAV_PROTOCOL_CAPABILITY[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_PROTOCOL_CAPABILITY(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_mav_result.go
+++ b/pkg/dialects/common/enum_mav_result.go
@@ -61,28 +61,28 @@ var values_MAV_RESULT = map[string]MAV_RESULT{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_RESULT) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_RESULT[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_RESULT[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_RESULT) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_RESULT[string(text)]
-	if !ok {
+	if value, ok := values_MAV_RESULT[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_RESULT(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_RESULT) String() string {
-	name, ok := labels_MAV_RESULT[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_RESULT[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_roi.go
+++ b/pkg/dialects/common/enum_mav_roi.go
@@ -43,28 +43,28 @@ var values_MAV_ROI = map[string]MAV_ROI{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_ROI) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_ROI[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_ROI[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_ROI) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_ROI[string(text)]
-	if !ok {
+	if value, ok := values_MAV_ROI[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_ROI(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_ROI) String() string {
-	name, ok := labels_MAV_ROI[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_ROI[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_sensor_orientation.go
+++ b/pkg/dialects/common/enum_mav_sensor_orientation.go
@@ -189,28 +189,28 @@ var values_MAV_SENSOR_ORIENTATION = map[string]MAV_SENSOR_ORIENTATION{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_SENSOR_ORIENTATION) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_SENSOR_ORIENTATION[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_SENSOR_ORIENTATION[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_SENSOR_ORIENTATION) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_SENSOR_ORIENTATION[string(text)]
-	if !ok {
+	if value, ok := values_MAV_SENSOR_ORIENTATION[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_SENSOR_ORIENTATION(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_SENSOR_ORIENTATION) String() string {
-	name, ok := labels_MAV_SENSOR_ORIENTATION[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_SENSOR_ORIENTATION[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_severity.go
+++ b/pkg/dialects/common/enum_mav_severity.go
@@ -53,28 +53,28 @@ var values_MAV_SEVERITY = map[string]MAV_SEVERITY{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_SEVERITY) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_SEVERITY[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_SEVERITY[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_SEVERITY) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_SEVERITY[string(text)]
-	if !ok {
+	if value, ok := values_MAV_SEVERITY[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_SEVERITY(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_SEVERITY) String() string {
-	name, ok := labels_MAV_SEVERITY[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_SEVERITY[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_sys_status_sensor.go
+++ b/pkg/dialects/common/enum_mav_sys_status_sensor.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -149,6 +150,9 @@ var values_MAV_SYS_STATUS_SENSOR = map[string]MAV_SYS_STATUS_SENSOR{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_SYS_STATUS_SENSOR) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 32; i++ {
 		mask := MAV_SYS_STATUS_SENSOR(1 << i)
@@ -166,6 +170,8 @@ func (e *MAV_SYS_STATUS_SENSOR) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_MAV_SYS_STATUS_SENSOR[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_SYS_STATUS_SENSOR(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_mav_sys_status_sensor_extended.go
+++ b/pkg/dialects/common/enum_mav_sys_status_sensor_extended.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -25,6 +26,9 @@ var values_MAV_SYS_STATUS_SENSOR_EXTENDED = map[string]MAV_SYS_STATUS_SENSOR_EXT
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_SYS_STATUS_SENSOR_EXTENDED) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 1; i++ {
 		mask := MAV_SYS_STATUS_SENSOR_EXTENDED(1 << i)
@@ -42,6 +46,8 @@ func (e *MAV_SYS_STATUS_SENSOR_EXTENDED) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_MAV_SYS_STATUS_SENSOR_EXTENDED[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_SYS_STATUS_SENSOR_EXTENDED(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_mav_tunnel_payload_type.go
+++ b/pkg/dialects/common/enum_mav_tunnel_payload_type.go
@@ -64,28 +64,28 @@ var values_MAV_TUNNEL_PAYLOAD_TYPE = map[string]MAV_TUNNEL_PAYLOAD_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_TUNNEL_PAYLOAD_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_TUNNEL_PAYLOAD_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_TUNNEL_PAYLOAD_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_TUNNEL_PAYLOAD_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_TUNNEL_PAYLOAD_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_TUNNEL_PAYLOAD_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_TUNNEL_PAYLOAD_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_TUNNEL_PAYLOAD_TYPE) String() string {
-	name, ok := labels_MAV_TUNNEL_PAYLOAD_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_TUNNEL_PAYLOAD_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_vtol_state.go
+++ b/pkg/dialects/common/enum_mav_vtol_state.go
@@ -41,28 +41,28 @@ var values_MAV_VTOL_STATE = map[string]MAV_VTOL_STATE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_VTOL_STATE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_VTOL_STATE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_VTOL_STATE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_VTOL_STATE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_VTOL_STATE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_VTOL_STATE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_VTOL_STATE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_VTOL_STATE) String() string {
-	name, ok := labels_MAV_VTOL_STATE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_VTOL_STATE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mav_winch_status_flag.go
+++ b/pkg/dialects/common/enum_mav_winch_status_flag.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -77,6 +78,9 @@ var values_MAV_WINCH_STATUS_FLAG = map[string]MAV_WINCH_STATUS_FLAG{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_WINCH_STATUS_FLAG) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 14; i++ {
 		mask := MAV_WINCH_STATUS_FLAG(1 << i)
@@ -94,6 +98,8 @@ func (e *MAV_WINCH_STATUS_FLAG) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_MAV_WINCH_STATUS_FLAG[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_WINCH_STATUS_FLAG(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_mavlink_data_stream_type.go
+++ b/pkg/dialects/common/enum_mavlink_data_stream_type.go
@@ -38,28 +38,28 @@ var values_MAVLINK_DATA_STREAM_TYPE = map[string]MAVLINK_DATA_STREAM_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAVLINK_DATA_STREAM_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAVLINK_DATA_STREAM_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAVLINK_DATA_STREAM_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAVLINK_DATA_STREAM_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAVLINK_DATA_STREAM_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAVLINK_DATA_STREAM_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAVLINK_DATA_STREAM_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAVLINK_DATA_STREAM_TYPE) String() string {
-	name, ok := labels_MAVLINK_DATA_STREAM_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAVLINK_DATA_STREAM_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_mission_state.go
+++ b/pkg/dialects/common/enum_mission_state.go
@@ -47,28 +47,28 @@ var values_MISSION_STATE = map[string]MISSION_STATE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MISSION_STATE) MarshalText() ([]byte, error) {
-	name, ok := labels_MISSION_STATE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MISSION_STATE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MISSION_STATE) UnmarshalText(text []byte) error {
-	value, ok := values_MISSION_STATE[string(text)]
-	if !ok {
+	if value, ok := values_MISSION_STATE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MISSION_STATE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MISSION_STATE) String() string {
-	name, ok := labels_MISSION_STATE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MISSION_STATE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_motor_test_order.go
+++ b/pkg/dialects/common/enum_motor_test_order.go
@@ -33,28 +33,28 @@ var values_MOTOR_TEST_ORDER = map[string]MOTOR_TEST_ORDER{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MOTOR_TEST_ORDER) MarshalText() ([]byte, error) {
-	name, ok := labels_MOTOR_TEST_ORDER[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MOTOR_TEST_ORDER[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MOTOR_TEST_ORDER) UnmarshalText(text []byte) error {
-	value, ok := values_MOTOR_TEST_ORDER[string(text)]
-	if !ok {
+	if value, ok := values_MOTOR_TEST_ORDER[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MOTOR_TEST_ORDER(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MOTOR_TEST_ORDER) String() string {
-	name, ok := labels_MOTOR_TEST_ORDER[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MOTOR_TEST_ORDER[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_motor_test_throttle_type.go
+++ b/pkg/dialects/common/enum_motor_test_throttle_type.go
@@ -37,28 +37,28 @@ var values_MOTOR_TEST_THROTTLE_TYPE = map[string]MOTOR_TEST_THROTTLE_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MOTOR_TEST_THROTTLE_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MOTOR_TEST_THROTTLE_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MOTOR_TEST_THROTTLE_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MOTOR_TEST_THROTTLE_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MOTOR_TEST_THROTTLE_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MOTOR_TEST_THROTTLE_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MOTOR_TEST_THROTTLE_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MOTOR_TEST_THROTTLE_TYPE) String() string {
-	name, ok := labels_MOTOR_TEST_THROTTLE_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MOTOR_TEST_THROTTLE_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_nav_vtol_land_options.go
+++ b/pkg/dialects/common/enum_nav_vtol_land_options.go
@@ -33,28 +33,28 @@ var values_NAV_VTOL_LAND_OPTIONS = map[string]NAV_VTOL_LAND_OPTIONS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e NAV_VTOL_LAND_OPTIONS) MarshalText() ([]byte, error) {
-	name, ok := labels_NAV_VTOL_LAND_OPTIONS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_NAV_VTOL_LAND_OPTIONS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *NAV_VTOL_LAND_OPTIONS) UnmarshalText(text []byte) error {
-	value, ok := values_NAV_VTOL_LAND_OPTIONS[string(text)]
-	if !ok {
+	if value, ok := values_NAV_VTOL_LAND_OPTIONS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = NAV_VTOL_LAND_OPTIONS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e NAV_VTOL_LAND_OPTIONS) String() string {
-	name, ok := labels_NAV_VTOL_LAND_OPTIONS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_NAV_VTOL_LAND_OPTIONS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_orbit_yaw_behaviour.go
+++ b/pkg/dialects/common/enum_orbit_yaw_behaviour.go
@@ -41,28 +41,28 @@ var values_ORBIT_YAW_BEHAVIOUR = map[string]ORBIT_YAW_BEHAVIOUR{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ORBIT_YAW_BEHAVIOUR) MarshalText() ([]byte, error) {
-	name, ok := labels_ORBIT_YAW_BEHAVIOUR[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_ORBIT_YAW_BEHAVIOUR[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ORBIT_YAW_BEHAVIOUR) UnmarshalText(text []byte) error {
-	value, ok := values_ORBIT_YAW_BEHAVIOUR[string(text)]
-	if !ok {
+	if value, ok := values_ORBIT_YAW_BEHAVIOUR[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = ORBIT_YAW_BEHAVIOUR(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ORBIT_YAW_BEHAVIOUR) String() string {
-	name, ok := labels_ORBIT_YAW_BEHAVIOUR[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_ORBIT_YAW_BEHAVIOUR[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_parachute_action.go
+++ b/pkg/dialects/common/enum_parachute_action.go
@@ -33,28 +33,28 @@ var values_PARACHUTE_ACTION = map[string]PARACHUTE_ACTION{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PARACHUTE_ACTION) MarshalText() ([]byte, error) {
-	name, ok := labels_PARACHUTE_ACTION[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_PARACHUTE_ACTION[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PARACHUTE_ACTION) UnmarshalText(text []byte) error {
-	value, ok := values_PARACHUTE_ACTION[string(text)]
-	if !ok {
+	if value, ok := values_PARACHUTE_ACTION[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = PARACHUTE_ACTION(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PARACHUTE_ACTION) String() string {
-	name, ok := labels_PARACHUTE_ACTION[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_PARACHUTE_ACTION[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_param_ack.go
+++ b/pkg/dialects/common/enum_param_ack.go
@@ -37,28 +37,28 @@ var values_PARAM_ACK = map[string]PARAM_ACK{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PARAM_ACK) MarshalText() ([]byte, error) {
-	name, ok := labels_PARAM_ACK[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_PARAM_ACK[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PARAM_ACK) UnmarshalText(text []byte) error {
-	value, ok := values_PARAM_ACK[string(text)]
-	if !ok {
+	if value, ok := values_PARAM_ACK[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = PARAM_ACK(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PARAM_ACK) String() string {
-	name, ok := labels_PARAM_ACK[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_PARAM_ACK[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_position_target_typemask.go
+++ b/pkg/dialects/common/enum_position_target_typemask.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -69,6 +70,9 @@ var values_POSITION_TARGET_TYPEMASK = map[string]POSITION_TARGET_TYPEMASK{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e POSITION_TARGET_TYPEMASK) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 12; i++ {
 		mask := POSITION_TARGET_TYPEMASK(1 << i)
@@ -86,6 +90,8 @@ func (e *POSITION_TARGET_TYPEMASK) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_POSITION_TARGET_TYPEMASK[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= POSITION_TARGET_TYPEMASK(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_precision_land_mode.go
+++ b/pkg/dialects/common/enum_precision_land_mode.go
@@ -33,28 +33,28 @@ var values_PRECISION_LAND_MODE = map[string]PRECISION_LAND_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PRECISION_LAND_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_PRECISION_LAND_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_PRECISION_LAND_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PRECISION_LAND_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_PRECISION_LAND_MODE[string(text)]
-	if !ok {
+	if value, ok := values_PRECISION_LAND_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = PRECISION_LAND_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PRECISION_LAND_MODE) String() string {
-	name, ok := labels_PRECISION_LAND_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_PRECISION_LAND_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_preflight_storage_mission_action.go
+++ b/pkg/dialects/common/enum_preflight_storage_mission_action.go
@@ -34,28 +34,28 @@ var values_PREFLIGHT_STORAGE_MISSION_ACTION = map[string]PREFLIGHT_STORAGE_MISSI
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PREFLIGHT_STORAGE_MISSION_ACTION) MarshalText() ([]byte, error) {
-	name, ok := labels_PREFLIGHT_STORAGE_MISSION_ACTION[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_PREFLIGHT_STORAGE_MISSION_ACTION[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PREFLIGHT_STORAGE_MISSION_ACTION) UnmarshalText(text []byte) error {
-	value, ok := values_PREFLIGHT_STORAGE_MISSION_ACTION[string(text)]
-	if !ok {
+	if value, ok := values_PREFLIGHT_STORAGE_MISSION_ACTION[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = PREFLIGHT_STORAGE_MISSION_ACTION(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PREFLIGHT_STORAGE_MISSION_ACTION) String() string {
-	name, ok := labels_PREFLIGHT_STORAGE_MISSION_ACTION[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_PREFLIGHT_STORAGE_MISSION_ACTION[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_preflight_storage_parameter_action.go
+++ b/pkg/dialects/common/enum_preflight_storage_parameter_action.go
@@ -42,28 +42,28 @@ var values_PREFLIGHT_STORAGE_PARAMETER_ACTION = map[string]PREFLIGHT_STORAGE_PAR
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PREFLIGHT_STORAGE_PARAMETER_ACTION) MarshalText() ([]byte, error) {
-	name, ok := labels_PREFLIGHT_STORAGE_PARAMETER_ACTION[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_PREFLIGHT_STORAGE_PARAMETER_ACTION[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PREFLIGHT_STORAGE_PARAMETER_ACTION) UnmarshalText(text []byte) error {
-	value, ok := values_PREFLIGHT_STORAGE_PARAMETER_ACTION[string(text)]
-	if !ok {
+	if value, ok := values_PREFLIGHT_STORAGE_PARAMETER_ACTION[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = PREFLIGHT_STORAGE_PARAMETER_ACTION(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PREFLIGHT_STORAGE_PARAMETER_ACTION) String() string {
-	name, ok := labels_PREFLIGHT_STORAGE_PARAMETER_ACTION[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_PREFLIGHT_STORAGE_PARAMETER_ACTION[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_rc_type.go
+++ b/pkg/dialects/common/enum_rc_type.go
@@ -29,28 +29,28 @@ var values_RC_TYPE = map[string]RC_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e RC_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_RC_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_RC_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *RC_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_RC_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_RC_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = RC_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e RC_TYPE) String() string {
-	name, ok := labels_RC_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_RC_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_rtk_baseline_coordinate_system.go
+++ b/pkg/dialects/common/enum_rtk_baseline_coordinate_system.go
@@ -29,28 +29,28 @@ var values_RTK_BASELINE_COORDINATE_SYSTEM = map[string]RTK_BASELINE_COORDINATE_S
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e RTK_BASELINE_COORDINATE_SYSTEM) MarshalText() ([]byte, error) {
-	name, ok := labels_RTK_BASELINE_COORDINATE_SYSTEM[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_RTK_BASELINE_COORDINATE_SYSTEM[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *RTK_BASELINE_COORDINATE_SYSTEM) UnmarshalText(text []byte) error {
-	value, ok := values_RTK_BASELINE_COORDINATE_SYSTEM[string(text)]
-	if !ok {
+	if value, ok := values_RTK_BASELINE_COORDINATE_SYSTEM[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = RTK_BASELINE_COORDINATE_SYSTEM(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e RTK_BASELINE_COORDINATE_SYSTEM) String() string {
-	name, ok := labels_RTK_BASELINE_COORDINATE_SYSTEM[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_RTK_BASELINE_COORDINATE_SYSTEM[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_serial_control_dev.go
+++ b/pkg/dialects/common/enum_serial_control_dev.go
@@ -81,28 +81,28 @@ var values_SERIAL_CONTROL_DEV = map[string]SERIAL_CONTROL_DEV{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e SERIAL_CONTROL_DEV) MarshalText() ([]byte, error) {
-	name, ok := labels_SERIAL_CONTROL_DEV[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_SERIAL_CONTROL_DEV[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *SERIAL_CONTROL_DEV) UnmarshalText(text []byte) error {
-	value, ok := values_SERIAL_CONTROL_DEV[string(text)]
-	if !ok {
+	if value, ok := values_SERIAL_CONTROL_DEV[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = SERIAL_CONTROL_DEV(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e SERIAL_CONTROL_DEV) String() string {
-	name, ok := labels_SERIAL_CONTROL_DEV[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_SERIAL_CONTROL_DEV[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_serial_control_flag.go
+++ b/pkg/dialects/common/enum_serial_control_flag.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -41,6 +42,9 @@ var values_SERIAL_CONTROL_FLAG = map[string]SERIAL_CONTROL_FLAG{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e SERIAL_CONTROL_FLAG) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 5; i++ {
 		mask := SERIAL_CONTROL_FLAG(1 << i)
@@ -58,6 +62,8 @@ func (e *SERIAL_CONTROL_FLAG) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_SERIAL_CONTROL_FLAG[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= SERIAL_CONTROL_FLAG(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_set_focus_type.go
+++ b/pkg/dialects/common/enum_set_focus_type.go
@@ -49,28 +49,28 @@ var values_SET_FOCUS_TYPE = map[string]SET_FOCUS_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e SET_FOCUS_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_SET_FOCUS_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_SET_FOCUS_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *SET_FOCUS_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_SET_FOCUS_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_SET_FOCUS_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = SET_FOCUS_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e SET_FOCUS_TYPE) String() string {
-	name, ok := labels_SET_FOCUS_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_SET_FOCUS_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_speed_type.go
+++ b/pkg/dialects/common/enum_speed_type.go
@@ -37,28 +37,28 @@ var values_SPEED_TYPE = map[string]SPEED_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e SPEED_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_SPEED_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_SPEED_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *SPEED_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_SPEED_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_SPEED_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = SPEED_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e SPEED_TYPE) String() string {
-	name, ok := labels_SPEED_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_SPEED_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_storage_status.go
+++ b/pkg/dialects/common/enum_storage_status.go
@@ -37,28 +37,28 @@ var values_STORAGE_STATUS = map[string]STORAGE_STATUS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e STORAGE_STATUS) MarshalText() ([]byte, error) {
-	name, ok := labels_STORAGE_STATUS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_STORAGE_STATUS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *STORAGE_STATUS) UnmarshalText(text []byte) error {
-	value, ok := values_STORAGE_STATUS[string(text)]
-	if !ok {
+	if value, ok := values_STORAGE_STATUS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = STORAGE_STATUS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e STORAGE_STATUS) String() string {
-	name, ok := labels_STORAGE_STATUS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_STORAGE_STATUS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_storage_type.go
+++ b/pkg/dialects/common/enum_storage_type.go
@@ -57,28 +57,28 @@ var values_STORAGE_TYPE = map[string]STORAGE_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e STORAGE_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_STORAGE_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_STORAGE_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *STORAGE_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_STORAGE_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_STORAGE_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = STORAGE_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e STORAGE_TYPE) String() string {
-	name, ok := labels_STORAGE_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_STORAGE_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_storage_usage_flag.go
+++ b/pkg/dialects/common/enum_storage_usage_flag.go
@@ -37,28 +37,28 @@ var values_STORAGE_USAGE_FLAG = map[string]STORAGE_USAGE_FLAG{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e STORAGE_USAGE_FLAG) MarshalText() ([]byte, error) {
-	name, ok := labels_STORAGE_USAGE_FLAG[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_STORAGE_USAGE_FLAG[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *STORAGE_USAGE_FLAG) UnmarshalText(text []byte) error {
-	value, ok := values_STORAGE_USAGE_FLAG[string(text)]
-	if !ok {
+	if value, ok := values_STORAGE_USAGE_FLAG[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = STORAGE_USAGE_FLAG(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e STORAGE_USAGE_FLAG) String() string {
-	name, ok := labels_STORAGE_USAGE_FLAG[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_STORAGE_USAGE_FLAG[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_tune_format.go
+++ b/pkg/dialects/common/enum_tune_format.go
@@ -29,28 +29,28 @@ var values_TUNE_FORMAT = map[string]TUNE_FORMAT{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e TUNE_FORMAT) MarshalText() ([]byte, error) {
-	name, ok := labels_TUNE_FORMAT[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_TUNE_FORMAT[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *TUNE_FORMAT) UnmarshalText(text []byte) error {
-	value, ok := values_TUNE_FORMAT[string(text)]
-	if !ok {
+	if value, ok := values_TUNE_FORMAT[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = TUNE_FORMAT(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e TUNE_FORMAT) String() string {
-	name, ok := labels_TUNE_FORMAT[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_TUNE_FORMAT[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_uavcan_node_health.go
+++ b/pkg/dialects/common/enum_uavcan_node_health.go
@@ -37,28 +37,28 @@ var values_UAVCAN_NODE_HEALTH = map[string]UAVCAN_NODE_HEALTH{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVCAN_NODE_HEALTH) MarshalText() ([]byte, error) {
-	name, ok := labels_UAVCAN_NODE_HEALTH[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_UAVCAN_NODE_HEALTH[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVCAN_NODE_HEALTH) UnmarshalText(text []byte) error {
-	value, ok := values_UAVCAN_NODE_HEALTH[string(text)]
-	if !ok {
+	if value, ok := values_UAVCAN_NODE_HEALTH[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = UAVCAN_NODE_HEALTH(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVCAN_NODE_HEALTH) String() string {
-	name, ok := labels_UAVCAN_NODE_HEALTH[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_UAVCAN_NODE_HEALTH[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_uavcan_node_mode.go
+++ b/pkg/dialects/common/enum_uavcan_node_mode.go
@@ -41,28 +41,28 @@ var values_UAVCAN_NODE_MODE = map[string]UAVCAN_NODE_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVCAN_NODE_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_UAVCAN_NODE_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_UAVCAN_NODE_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVCAN_NODE_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_UAVCAN_NODE_MODE[string(text)]
-	if !ok {
+	if value, ok := values_UAVCAN_NODE_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = UAVCAN_NODE_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVCAN_NODE_MODE) String() string {
-	name, ok := labels_UAVCAN_NODE_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_UAVCAN_NODE_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_utm_data_avail_flags.go
+++ b/pkg/dialects/common/enum_utm_data_avail_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -53,6 +54,9 @@ var values_UTM_DATA_AVAIL_FLAGS = map[string]UTM_DATA_AVAIL_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UTM_DATA_AVAIL_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 8; i++ {
 		mask := UTM_DATA_AVAIL_FLAGS(1 << i)
@@ -70,6 +74,8 @@ func (e *UTM_DATA_AVAIL_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_UTM_DATA_AVAIL_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= UTM_DATA_AVAIL_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_utm_flight_state.go
+++ b/pkg/dialects/common/enum_utm_flight_state.go
@@ -41,28 +41,28 @@ var values_UTM_FLIGHT_STATE = map[string]UTM_FLIGHT_STATE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UTM_FLIGHT_STATE) MarshalText() ([]byte, error) {
-	name, ok := labels_UTM_FLIGHT_STATE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_UTM_FLIGHT_STATE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UTM_FLIGHT_STATE) UnmarshalText(text []byte) error {
-	value, ok := values_UTM_FLIGHT_STATE[string(text)]
-	if !ok {
+	if value, ok := values_UTM_FLIGHT_STATE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = UTM_FLIGHT_STATE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UTM_FLIGHT_STATE) String() string {
-	name, ok := labels_UTM_FLIGHT_STATE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_UTM_FLIGHT_STATE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_video_stream_status_flags.go
+++ b/pkg/dialects/common/enum_video_stream_status_flags.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -29,6 +30,9 @@ var values_VIDEO_STREAM_STATUS_FLAGS = map[string]VIDEO_STREAM_STATUS_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e VIDEO_STREAM_STATUS_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 2; i++ {
 		mask := VIDEO_STREAM_STATUS_FLAGS(1 << i)
@@ -46,6 +50,8 @@ func (e *VIDEO_STREAM_STATUS_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_VIDEO_STREAM_STATUS_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= VIDEO_STREAM_STATUS_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/common/enum_video_stream_type.go
+++ b/pkg/dialects/common/enum_video_stream_type.go
@@ -37,28 +37,28 @@ var values_VIDEO_STREAM_TYPE = map[string]VIDEO_STREAM_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e VIDEO_STREAM_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_VIDEO_STREAM_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_VIDEO_STREAM_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *VIDEO_STREAM_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_VIDEO_STREAM_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_VIDEO_STREAM_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = VIDEO_STREAM_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e VIDEO_STREAM_TYPE) String() string {
-	name, ok := labels_VIDEO_STREAM_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_VIDEO_STREAM_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_vtol_transition_heading.go
+++ b/pkg/dialects/common/enum_vtol_transition_heading.go
@@ -41,28 +41,28 @@ var values_VTOL_TRANSITION_HEADING = map[string]VTOL_TRANSITION_HEADING{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e VTOL_TRANSITION_HEADING) MarshalText() ([]byte, error) {
-	name, ok := labels_VTOL_TRANSITION_HEADING[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_VTOL_TRANSITION_HEADING[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *VTOL_TRANSITION_HEADING) UnmarshalText(text []byte) error {
-	value, ok := values_VTOL_TRANSITION_HEADING[string(text)]
-	if !ok {
+	if value, ok := values_VTOL_TRANSITION_HEADING[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = VTOL_TRANSITION_HEADING(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e VTOL_TRANSITION_HEADING) String() string {
-	name, ok := labels_VTOL_TRANSITION_HEADING[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_VTOL_TRANSITION_HEADING[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_wifi_config_ap_mode.go
+++ b/pkg/dialects/common/enum_wifi_config_ap_mode.go
@@ -37,28 +37,28 @@ var values_WIFI_CONFIG_AP_MODE = map[string]WIFI_CONFIG_AP_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e WIFI_CONFIG_AP_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_WIFI_CONFIG_AP_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_WIFI_CONFIG_AP_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *WIFI_CONFIG_AP_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_WIFI_CONFIG_AP_MODE[string(text)]
-	if !ok {
+	if value, ok := values_WIFI_CONFIG_AP_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = WIFI_CONFIG_AP_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e WIFI_CONFIG_AP_MODE) String() string {
-	name, ok := labels_WIFI_CONFIG_AP_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_WIFI_CONFIG_AP_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_wifi_config_ap_response.go
+++ b/pkg/dialects/common/enum_wifi_config_ap_response.go
@@ -45,28 +45,28 @@ var values_WIFI_CONFIG_AP_RESPONSE = map[string]WIFI_CONFIG_AP_RESPONSE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e WIFI_CONFIG_AP_RESPONSE) MarshalText() ([]byte, error) {
-	name, ok := labels_WIFI_CONFIG_AP_RESPONSE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_WIFI_CONFIG_AP_RESPONSE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *WIFI_CONFIG_AP_RESPONSE) UnmarshalText(text []byte) error {
-	value, ok := values_WIFI_CONFIG_AP_RESPONSE[string(text)]
-	if !ok {
+	if value, ok := values_WIFI_CONFIG_AP_RESPONSE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = WIFI_CONFIG_AP_RESPONSE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e WIFI_CONFIG_AP_RESPONSE) String() string {
-	name, ok := labels_WIFI_CONFIG_AP_RESPONSE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_WIFI_CONFIG_AP_RESPONSE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/common/enum_winch_actions.go
+++ b/pkg/dialects/common/enum_winch_actions.go
@@ -61,28 +61,28 @@ var values_WINCH_ACTIONS = map[string]WINCH_ACTIONS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e WINCH_ACTIONS) MarshalText() ([]byte, error) {
-	name, ok := labels_WINCH_ACTIONS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_WINCH_ACTIONS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *WINCH_ACTIONS) UnmarshalText(text []byte) error {
-	value, ok := values_WINCH_ACTIONS[string(text)]
-	if !ok {
+	if value, ok := values_WINCH_ACTIONS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = WINCH_ACTIONS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e WINCH_ACTIONS) String() string {
-	name, ok := labels_WINCH_ACTIONS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_WINCH_ACTIONS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/csairlink/enum_airlink_auth_response_type.go
+++ b/pkg/dialects/csairlink/enum_airlink_auth_response_type.go
@@ -28,28 +28,28 @@ var values_AIRLINK_AUTH_RESPONSE_TYPE = map[string]AIRLINK_AUTH_RESPONSE_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e AIRLINK_AUTH_RESPONSE_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_AIRLINK_AUTH_RESPONSE_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_AIRLINK_AUTH_RESPONSE_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *AIRLINK_AUTH_RESPONSE_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_AIRLINK_AUTH_RESPONSE_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_AIRLINK_AUTH_RESPONSE_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = AIRLINK_AUTH_RESPONSE_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e AIRLINK_AUTH_RESPONSE_TYPE) String() string {
-	name, ok := labels_AIRLINK_AUTH_RESPONSE_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_AIRLINK_AUTH_RESPONSE_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/development/enum_airspeed_sensor_flags.go
+++ b/pkg/dialects/development/enum_airspeed_sensor_flags.go
@@ -4,6 +4,7 @@ package development
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -29,6 +30,9 @@ var values_AIRSPEED_SENSOR_FLAGS = map[string]AIRSPEED_SENSOR_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e AIRSPEED_SENSOR_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 2; i++ {
 		mask := AIRSPEED_SENSOR_FLAGS(1 << i)
@@ -46,6 +50,8 @@ func (e *AIRSPEED_SENSOR_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_AIRSPEED_SENSOR_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= AIRSPEED_SENSOR_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/development/enum_mav_battery_status_flags.go
+++ b/pkg/dialects/development/enum_mav_battery_status_flags.go
@@ -4,6 +4,7 @@ package development
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -120,6 +121,9 @@ var values_MAV_BATTERY_STATUS_FLAGS = map[string]MAV_BATTERY_STATUS_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_BATTERY_STATUS_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 20; i++ {
 		mask := MAV_BATTERY_STATUS_FLAGS(1 << i)
@@ -137,6 +141,8 @@ func (e *MAV_BATTERY_STATUS_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_MAV_BATTERY_STATUS_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_BATTERY_STATUS_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/development/enum_mav_cmd.go
+++ b/pkg/dialects/development/enum_mav_cmd.go
@@ -757,28 +757,28 @@ var values_MAV_CMD = map[string]MAV_CMD{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_CMD[string(text)]
-	if !ok {
+	if value, ok := values_MAV_CMD[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_CMD(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD) String() string {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/development/enum_mav_mode_property.go
+++ b/pkg/dialects/development/enum_mav_mode_property.go
@@ -4,6 +4,7 @@ package development
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -32,6 +33,9 @@ var values_MAV_MODE_PROPERTY = map[string]MAV_MODE_PROPERTY{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MODE_PROPERTY) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 2; i++ {
 		mask := MAV_MODE_PROPERTY(1 << i)
@@ -49,6 +53,8 @@ func (e *MAV_MODE_PROPERTY) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_MAV_MODE_PROPERTY[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_MODE_PROPERTY(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/development/enum_mav_standard_mode.go
+++ b/pkg/dialects/development/enum_mav_standard_mode.go
@@ -102,28 +102,28 @@ var values_MAV_STANDARD_MODE = map[string]MAV_STANDARD_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STANDARD_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_STANDARD_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_STANDARD_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_STANDARD_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_STANDARD_MODE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_STANDARD_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_STANDARD_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_STANDARD_MODE) String() string {
-	name, ok := labels_MAV_STANDARD_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_STANDARD_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/development/enum_param_transaction_action.go
+++ b/pkg/dialects/development/enum_param_transaction_action.go
@@ -33,28 +33,28 @@ var values_PARAM_TRANSACTION_ACTION = map[string]PARAM_TRANSACTION_ACTION{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PARAM_TRANSACTION_ACTION) MarshalText() ([]byte, error) {
-	name, ok := labels_PARAM_TRANSACTION_ACTION[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_PARAM_TRANSACTION_ACTION[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PARAM_TRANSACTION_ACTION) UnmarshalText(text []byte) error {
-	value, ok := values_PARAM_TRANSACTION_ACTION[string(text)]
-	if !ok {
+	if value, ok := values_PARAM_TRANSACTION_ACTION[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = PARAM_TRANSACTION_ACTION(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PARAM_TRANSACTION_ACTION) String() string {
-	name, ok := labels_PARAM_TRANSACTION_ACTION[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_PARAM_TRANSACTION_ACTION[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/development/enum_param_transaction_transport.go
+++ b/pkg/dialects/development/enum_param_transaction_transport.go
@@ -29,28 +29,28 @@ var values_PARAM_TRANSACTION_TRANSPORT = map[string]PARAM_TRANSACTION_TRANSPORT{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e PARAM_TRANSACTION_TRANSPORT) MarshalText() ([]byte, error) {
-	name, ok := labels_PARAM_TRANSACTION_TRANSPORT[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_PARAM_TRANSACTION_TRANSPORT[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *PARAM_TRANSACTION_TRANSPORT) UnmarshalText(text []byte) error {
-	value, ok := values_PARAM_TRANSACTION_TRANSPORT[string(text)]
-	if !ok {
+	if value, ok := values_PARAM_TRANSACTION_TRANSPORT[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = PARAM_TRANSACTION_TRANSPORT(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e PARAM_TRANSACTION_TRANSPORT) String() string {
-	name, ok := labels_PARAM_TRANSACTION_TRANSPORT[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_PARAM_TRANSACTION_TRANSPORT[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/development/enum_target_absolute_sensor_capability_flags.go
+++ b/pkg/dialects/development/enum_target_absolute_sensor_capability_flags.go
@@ -4,6 +4,7 @@ package development
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -36,6 +37,9 @@ var values_TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS = map[string]TARGET_ABSOLUTE_
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 5; i++ {
 		mask := TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS(1 << i)
@@ -53,6 +57,8 @@ func (e *TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS) UnmarshalText(text []byte) err
 	for _, label := range labels {
 		if value, ok := values_TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/development/enum_target_obs_frame.go
+++ b/pkg/dialects/development/enum_target_obs_frame.go
@@ -37,28 +37,28 @@ var values_TARGET_OBS_FRAME = map[string]TARGET_OBS_FRAME{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e TARGET_OBS_FRAME) MarshalText() ([]byte, error) {
-	name, ok := labels_TARGET_OBS_FRAME[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_TARGET_OBS_FRAME[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *TARGET_OBS_FRAME) UnmarshalText(text []byte) error {
-	value, ok := values_TARGET_OBS_FRAME[string(text)]
-	if !ok {
+	if value, ok := values_TARGET_OBS_FRAME[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = TARGET_OBS_FRAME(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e TARGET_OBS_FRAME) String() string {
-	name, ok := labels_TARGET_OBS_FRAME[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_TARGET_OBS_FRAME[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/development/enum_wifi_network_security.go
+++ b/pkg/dialects/development/enum_wifi_network_security.go
@@ -45,28 +45,28 @@ var values_WIFI_NETWORK_SECURITY = map[string]WIFI_NETWORK_SECURITY{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e WIFI_NETWORK_SECURITY) MarshalText() ([]byte, error) {
-	name, ok := labels_WIFI_NETWORK_SECURITY[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_WIFI_NETWORK_SECURITY[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *WIFI_NETWORK_SECURITY) UnmarshalText(text []byte) error {
-	value, ok := values_WIFI_NETWORK_SECURITY[string(text)]
-	if !ok {
+	if value, ok := values_WIFI_NETWORK_SECURITY[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = WIFI_NETWORK_SECURITY(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e WIFI_NETWORK_SECURITY) String() string {
-	name, ok := labels_WIFI_NETWORK_SECURITY[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_WIFI_NETWORK_SECURITY[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/icarous/enum_icarous_fms_state.go
+++ b/pkg/dialects/icarous/enum_icarous_fms_state.go
@@ -38,28 +38,28 @@ var values_ICAROUS_FMS_STATE = map[string]ICAROUS_FMS_STATE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ICAROUS_FMS_STATE) MarshalText() ([]byte, error) {
-	name, ok := labels_ICAROUS_FMS_STATE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_ICAROUS_FMS_STATE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ICAROUS_FMS_STATE) UnmarshalText(text []byte) error {
-	value, ok := values_ICAROUS_FMS_STATE[string(text)]
-	if !ok {
+	if value, ok := values_ICAROUS_FMS_STATE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = ICAROUS_FMS_STATE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ICAROUS_FMS_STATE) String() string {
-	name, ok := labels_ICAROUS_FMS_STATE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_ICAROUS_FMS_STATE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/icarous/enum_icarous_track_band_types.go
+++ b/pkg/dialects/icarous/enum_icarous_track_band_types.go
@@ -29,28 +29,28 @@ var values_ICAROUS_TRACK_BAND_TYPES = map[string]ICAROUS_TRACK_BAND_TYPES{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e ICAROUS_TRACK_BAND_TYPES) MarshalText() ([]byte, error) {
-	name, ok := labels_ICAROUS_TRACK_BAND_TYPES[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_ICAROUS_TRACK_BAND_TYPES[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *ICAROUS_TRACK_BAND_TYPES) UnmarshalText(text []byte) error {
-	value, ok := values_ICAROUS_TRACK_BAND_TYPES[string(text)]
-	if !ok {
+	if value, ok := values_ICAROUS_TRACK_BAND_TYPES[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = ICAROUS_TRACK_BAND_TYPES(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e ICAROUS_TRACK_BAND_TYPES) String() string {
-	name, ok := labels_ICAROUS_TRACK_BAND_TYPES[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_ICAROUS_TRACK_BAND_TYPES[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/matrixpilot/enum_mav_cmd.go
+++ b/pkg/dialects/matrixpilot/enum_mav_cmd.go
@@ -710,28 +710,28 @@ var values_MAV_CMD = map[string]MAV_CMD{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_CMD[string(text)]
-	if !ok {
+	if value, ok := values_MAV_CMD[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_CMD(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD) String() string {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/matrixpilot/enum_mav_preflight_storage_action.go
+++ b/pkg/dialects/matrixpilot/enum_mav_preflight_storage_action.go
@@ -49,28 +49,28 @@ var values_MAV_PREFLIGHT_STORAGE_ACTION = map[string]MAV_PREFLIGHT_STORAGE_ACTIO
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_PREFLIGHT_STORAGE_ACTION) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_PREFLIGHT_STORAGE_ACTION[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_PREFLIGHT_STORAGE_ACTION[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_PREFLIGHT_STORAGE_ACTION) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_PREFLIGHT_STORAGE_ACTION[string(text)]
-	if !ok {
+	if value, ok := values_MAV_PREFLIGHT_STORAGE_ACTION[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_PREFLIGHT_STORAGE_ACTION(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_PREFLIGHT_STORAGE_ACTION) String() string {
-	name, ok := labels_MAV_PREFLIGHT_STORAGE_ACTION[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_PREFLIGHT_STORAGE_ACTION[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/minimal/enum_mav_autopilot.go
+++ b/pkg/dialects/minimal/enum_mav_autopilot.go
@@ -105,28 +105,28 @@ var values_MAV_AUTOPILOT = map[string]MAV_AUTOPILOT{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_AUTOPILOT) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_AUTOPILOT[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_AUTOPILOT[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_AUTOPILOT) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_AUTOPILOT[string(text)]
-	if !ok {
+	if value, ok := values_MAV_AUTOPILOT[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_AUTOPILOT(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_AUTOPILOT) String() string {
-	name, ok := labels_MAV_AUTOPILOT[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_AUTOPILOT[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/minimal/enum_mav_component.go
+++ b/pkg/dialects/minimal/enum_mav_component.go
@@ -563,28 +563,28 @@ var values_MAV_COMPONENT = map[string]MAV_COMPONENT{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_COMPONENT) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_COMPONENT[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_COMPONENT[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_COMPONENT) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_COMPONENT[string(text)]
-	if !ok {
+	if value, ok := values_MAV_COMPONENT[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_COMPONENT(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_COMPONENT) String() string {
-	name, ok := labels_MAV_COMPONENT[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_COMPONENT[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/minimal/enum_mav_mode_flag.go
+++ b/pkg/dialects/minimal/enum_mav_mode_flag.go
@@ -4,6 +4,7 @@ package minimal
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -53,6 +54,9 @@ var values_MAV_MODE_FLAG = map[string]MAV_MODE_FLAG{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MODE_FLAG) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 8; i++ {
 		mask := MAV_MODE_FLAG(1 << i)
@@ -70,6 +74,8 @@ func (e *MAV_MODE_FLAG) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_MAV_MODE_FLAG[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_MODE_FLAG(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/minimal/enum_mav_mode_flag_decode_position.go
+++ b/pkg/dialects/minimal/enum_mav_mode_flag_decode_position.go
@@ -4,6 +4,7 @@ package minimal
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -53,6 +54,9 @@ var values_MAV_MODE_FLAG_DECODE_POSITION = map[string]MAV_MODE_FLAG_DECODE_POSIT
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_MODE_FLAG_DECODE_POSITION) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 8; i++ {
 		mask := MAV_MODE_FLAG_DECODE_POSITION(1 << i)
@@ -70,6 +74,8 @@ func (e *MAV_MODE_FLAG_DECODE_POSITION) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_MAV_MODE_FLAG_DECODE_POSITION[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_MODE_FLAG_DECODE_POSITION(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/minimal/enum_mav_state.go
+++ b/pkg/dialects/minimal/enum_mav_state.go
@@ -56,28 +56,28 @@ var values_MAV_STATE = map[string]MAV_STATE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STATE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_STATE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_STATE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_STATE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_STATE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_STATE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_STATE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_STATE) String() string {
-	name, ok := labels_MAV_STATE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_STATE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/minimal/enum_mav_type.go
+++ b/pkg/dialects/minimal/enum_mav_type.go
@@ -197,28 +197,28 @@ var values_MAV_TYPE = map[string]MAV_TYPE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_TYPE) String() string {
-	name, ok := labels_MAV_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/storm32/enum_mav_cmd.go
+++ b/pkg/dialects/storm32/enum_mav_cmd.go
@@ -847,28 +847,28 @@ var values_MAV_CMD = map[string]MAV_CMD{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_CMD) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_CMD) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_CMD[string(text)]
-	if !ok {
+	if value, ok := values_MAV_CMD[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_CMD(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_CMD) String() string {
-	name, ok := labels_MAV_CMD[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_CMD[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/storm32/enum_mav_qshot_mode.go
+++ b/pkg/dialects/storm32/enum_mav_qshot_mode.go
@@ -61,28 +61,28 @@ var values_MAV_QSHOT_MODE = map[string]MAV_QSHOT_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_QSHOT_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_QSHOT_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_QSHOT_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_QSHOT_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_QSHOT_MODE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_QSHOT_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_QSHOT_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_QSHOT_MODE) String() string {
-	name, ok := labels_MAV_QSHOT_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_QSHOT_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/storm32/enum_mav_storm32_camera_prearm_flags.go
+++ b/pkg/dialects/storm32/enum_mav_storm32_camera_prearm_flags.go
@@ -4,6 +4,7 @@ package storm32
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -25,6 +26,9 @@ var values_MAV_STORM32_CAMERA_PREARM_FLAGS = map[string]MAV_STORM32_CAMERA_PREAR
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STORM32_CAMERA_PREARM_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 1; i++ {
 		mask := MAV_STORM32_CAMERA_PREARM_FLAGS(1 << i)
@@ -42,6 +46,8 @@ func (e *MAV_STORM32_CAMERA_PREARM_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_MAV_STORM32_CAMERA_PREARM_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_STORM32_CAMERA_PREARM_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_cap_flags.go
+++ b/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_cap_flags.go
@@ -4,6 +4,7 @@ package storm32
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -25,6 +26,9 @@ var values_MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS = map[string]MAV_STORM32_GIMBAL_
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 1; i++ {
 		mask := MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS(1 << i)
@@ -42,6 +46,8 @@ func (e *MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS) UnmarshalText(text []byte) error 
 	for _, label := range labels {
 		if value, ok := values_MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_client.go
+++ b/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_client.go
@@ -57,28 +57,28 @@ var values_MAV_STORM32_GIMBAL_MANAGER_CLIENT = map[string]MAV_STORM32_GIMBAL_MAN
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STORM32_GIMBAL_MANAGER_CLIENT) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_STORM32_GIMBAL_MANAGER_CLIENT[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_STORM32_GIMBAL_MANAGER_CLIENT[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_STORM32_GIMBAL_MANAGER_CLIENT) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_STORM32_GIMBAL_MANAGER_CLIENT[string(text)]
-	if !ok {
+	if value, ok := values_MAV_STORM32_GIMBAL_MANAGER_CLIENT[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_STORM32_GIMBAL_MANAGER_CLIENT(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_STORM32_GIMBAL_MANAGER_CLIENT) String() string {
-	name, ok := labels_MAV_STORM32_GIMBAL_MANAGER_CLIENT[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_STORM32_GIMBAL_MANAGER_CLIENT[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_flags.go
+++ b/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_flags.go
@@ -4,6 +4,7 @@ package storm32
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -69,6 +70,9 @@ var values_MAV_STORM32_GIMBAL_MANAGER_FLAGS = map[string]MAV_STORM32_GIMBAL_MANA
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STORM32_GIMBAL_MANAGER_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 12; i++ {
 		mask := MAV_STORM32_GIMBAL_MANAGER_FLAGS(1 << i)
@@ -86,6 +90,8 @@ func (e *MAV_STORM32_GIMBAL_MANAGER_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_MAV_STORM32_GIMBAL_MANAGER_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_STORM32_GIMBAL_MANAGER_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_profile.go
+++ b/pkg/dialects/storm32/enum_mav_storm32_gimbal_manager_profile.go
@@ -45,28 +45,28 @@ var values_MAV_STORM32_GIMBAL_MANAGER_PROFILE = map[string]MAV_STORM32_GIMBAL_MA
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STORM32_GIMBAL_MANAGER_PROFILE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_STORM32_GIMBAL_MANAGER_PROFILE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_STORM32_GIMBAL_MANAGER_PROFILE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_STORM32_GIMBAL_MANAGER_PROFILE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_STORM32_GIMBAL_MANAGER_PROFILE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_STORM32_GIMBAL_MANAGER_PROFILE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_STORM32_GIMBAL_MANAGER_PROFILE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_STORM32_GIMBAL_MANAGER_PROFILE) String() string {
-	name, ok := labels_MAV_STORM32_GIMBAL_MANAGER_PROFILE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_STORM32_GIMBAL_MANAGER_PROFILE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/storm32/enum_mav_storm32_gimbal_prearm_flags.go
+++ b/pkg/dialects/storm32/enum_mav_storm32_gimbal_prearm_flags.go
@@ -4,6 +4,7 @@ package storm32
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -73,6 +74,9 @@ var values_MAV_STORM32_GIMBAL_PREARM_FLAGS = map[string]MAV_STORM32_GIMBAL_PREAR
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STORM32_GIMBAL_PREARM_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 13; i++ {
 		mask := MAV_STORM32_GIMBAL_PREARM_FLAGS(1 << i)
@@ -90,6 +94,8 @@ func (e *MAV_STORM32_GIMBAL_PREARM_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_MAV_STORM32_GIMBAL_PREARM_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= MAV_STORM32_GIMBAL_PREARM_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/storm32/enum_mav_storm32_tunnel_payload_type.go
+++ b/pkg/dialects/storm32/enum_mav_storm32_tunnel_payload_type.go
@@ -44,28 +44,28 @@ var values_MAV_STORM32_TUNNEL_PAYLOAD_TYPE = map[string]MAV_STORM32_TUNNEL_PAYLO
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e MAV_STORM32_TUNNEL_PAYLOAD_TYPE) MarshalText() ([]byte, error) {
-	name, ok := labels_MAV_STORM32_TUNNEL_PAYLOAD_TYPE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_MAV_STORM32_TUNNEL_PAYLOAD_TYPE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *MAV_STORM32_TUNNEL_PAYLOAD_TYPE) UnmarshalText(text []byte) error {
-	value, ok := values_MAV_STORM32_TUNNEL_PAYLOAD_TYPE[string(text)]
-	if !ok {
+	if value, ok := values_MAV_STORM32_TUNNEL_PAYLOAD_TYPE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = MAV_STORM32_TUNNEL_PAYLOAD_TYPE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e MAV_STORM32_TUNNEL_PAYLOAD_TYPE) String() string {
-	name, ok := labels_MAV_STORM32_TUNNEL_PAYLOAD_TYPE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_MAV_STORM32_TUNNEL_PAYLOAD_TYPE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/storm32/enum_radio_link_stats_flags.go
+++ b/pkg/dialects/storm32/enum_radio_link_stats_flags.go
@@ -4,6 +4,7 @@ package storm32
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -25,6 +26,9 @@ var values_RADIO_LINK_STATS_FLAGS = map[string]RADIO_LINK_STATS_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e RADIO_LINK_STATS_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 1; i++ {
 		mask := RADIO_LINK_STATS_FLAGS(1 << i)
@@ -42,6 +46,8 @@ func (e *RADIO_LINK_STATS_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_RADIO_LINK_STATS_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= RADIO_LINK_STATS_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/storm32/enum_radio_rc_channels_flags.go
+++ b/pkg/dialects/storm32/enum_radio_rc_channels_flags.go
@@ -4,6 +4,7 @@ package storm32
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -29,6 +30,9 @@ var values_RADIO_RC_CHANNELS_FLAGS = map[string]RADIO_RC_CHANNELS_FLAGS{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e RADIO_RC_CHANNELS_FLAGS) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 2; i++ {
 		mask := RADIO_RC_CHANNELS_FLAGS(1 << i)
@@ -46,6 +50,8 @@ func (e *RADIO_RC_CHANNELS_FLAGS) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_RADIO_RC_CHANNELS_FLAGS[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= RADIO_RC_CHANNELS_FLAGS(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/ualberta/enum_ualberta_autopilot_mode.go
+++ b/pkg/dialects/ualberta/enum_ualberta_autopilot_mode.go
@@ -38,28 +38,28 @@ var values_UALBERTA_AUTOPILOT_MODE = map[string]UALBERTA_AUTOPILOT_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UALBERTA_AUTOPILOT_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_UALBERTA_AUTOPILOT_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_UALBERTA_AUTOPILOT_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UALBERTA_AUTOPILOT_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_UALBERTA_AUTOPILOT_MODE[string(text)]
-	if !ok {
+	if value, ok := values_UALBERTA_AUTOPILOT_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = UALBERTA_AUTOPILOT_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UALBERTA_AUTOPILOT_MODE) String() string {
-	name, ok := labels_UALBERTA_AUTOPILOT_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_UALBERTA_AUTOPILOT_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ualberta/enum_ualberta_nav_mode.go
+++ b/pkg/dialects/ualberta/enum_ualberta_nav_mode.go
@@ -36,28 +36,28 @@ var values_UALBERTA_NAV_MODE = map[string]UALBERTA_NAV_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UALBERTA_NAV_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_UALBERTA_NAV_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_UALBERTA_NAV_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UALBERTA_NAV_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_UALBERTA_NAV_MODE[string(text)]
-	if !ok {
+	if value, ok := values_UALBERTA_NAV_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = UALBERTA_NAV_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UALBERTA_NAV_MODE) String() string {
-	name, ok := labels_UALBERTA_NAV_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_UALBERTA_NAV_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/ualberta/enum_ualberta_pilot_mode.go
+++ b/pkg/dialects/ualberta/enum_ualberta_pilot_mode.go
@@ -31,28 +31,28 @@ var values_UALBERTA_PILOT_MODE = map[string]UALBERTA_PILOT_MODE{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UALBERTA_PILOT_MODE) MarshalText() ([]byte, error) {
-	name, ok := labels_UALBERTA_PILOT_MODE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_UALBERTA_PILOT_MODE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UALBERTA_PILOT_MODE) UnmarshalText(text []byte) error {
-	value, ok := values_UALBERTA_PILOT_MODE[string(text)]
-	if !ok {
+	if value, ok := values_UALBERTA_PILOT_MODE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = UALBERTA_PILOT_MODE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UALBERTA_PILOT_MODE) String() string {
-	name, ok := labels_UALBERTA_PILOT_MODE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_UALBERTA_PILOT_MODE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_emergency_status.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_emergency_status.go
@@ -45,28 +45,28 @@ var values_UAVIONIX_ADSB_EMERGENCY_STATUS = map[string]UAVIONIX_ADSB_EMERGENCY_S
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_EMERGENCY_STATUS) MarshalText() ([]byte, error) {
-	name, ok := labels_UAVIONIX_ADSB_EMERGENCY_STATUS[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_UAVIONIX_ADSB_EMERGENCY_STATUS[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVIONIX_ADSB_EMERGENCY_STATUS) UnmarshalText(text []byte) error {
-	value, ok := values_UAVIONIX_ADSB_EMERGENCY_STATUS[string(text)]
-	if !ok {
+	if value, ok := values_UAVIONIX_ADSB_EMERGENCY_STATUS[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = UAVIONIX_ADSB_EMERGENCY_STATUS(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVIONIX_ADSB_EMERGENCY_STATUS) String() string {
-	name, ok := labels_UAVIONIX_ADSB_EMERGENCY_STATUS[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_UAVIONIX_ADSB_EMERGENCY_STATUS[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_out_cfg_aircraft_size.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_out_cfg_aircraft_size.go
@@ -69,28 +69,28 @@ var values_UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE = map[string]UAVIONIX_ADSB_OUT_CF
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE) MarshalText() ([]byte, error) {
-	name, ok := labels_UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE) UnmarshalText(text []byte) error {
-	value, ok := values_UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE[string(text)]
-	if !ok {
+	if value, ok := values_UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE) String() string {
-	name, ok := labels_UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_out_cfg_gps_offset_lat.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_out_cfg_gps_offset_lat.go
@@ -45,28 +45,28 @@ var values_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT = map[string]UAVIONIX_ADSB_OUT_C
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT) MarshalText() ([]byte, error) {
-	name, ok := labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT) UnmarshalText(text []byte) error {
-	value, ok := values_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT[string(text)]
-	if !ok {
+	if value, ok := values_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT) String() string {
-	name, ok := labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_out_cfg_gps_offset_lon.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_out_cfg_gps_offset_lon.go
@@ -27,28 +27,28 @@ var values_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON = map[string]UAVIONIX_ADSB_OUT_C
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON) MarshalText() ([]byte, error) {
-	name, ok := labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON) UnmarshalText(text []byte) error {
-	value, ok := values_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON[string(text)]
-	if !ok {
+	if value, ok := values_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON) String() string {
-	name, ok := labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_out_dynamic_gps_fix.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_out_dynamic_gps_fix.go
@@ -39,28 +39,28 @@ var values_UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX = map[string]UAVIONIX_ADSB_OUT_DYNA
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX) MarshalText() ([]byte, error) {
-	name, ok := labels_UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX[e]
-	if !ok {
-		return nil, fmt.Errorf("invalid value %d", e)
+	if name, ok := labels_UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX[e]; ok {
+		return []byte(name), nil
 	}
-	return []byte(name), nil
+	return []byte(strconv.Itoa(int(e))), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (e *UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX) UnmarshalText(text []byte) error {
-	value, ok := values_UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX[string(text)]
-	if !ok {
+	if value, ok := values_UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX[string(text)]; ok {
+		*e = value
+	} else if value, err := strconv.Atoi(string(text)); err == nil {
+		*e = UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX(value)
+	} else {
 		return fmt.Errorf("invalid label '%s'", text)
 	}
-	*e = value
 	return nil
 }
 
 // String implements the fmt.Stringer interface.
 func (e UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX) String() string {
-	name, ok := labels_UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX[e]
-	if !ok {
-		return strconv.Itoa(int(e))
+	if name, ok := labels_UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX[e]; ok {
+		return name
 	}
-	return name
+	return strconv.Itoa(int(e))
 }

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_out_dynamic_state.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_out_dynamic_state.go
@@ -4,6 +4,7 @@ package uavionix
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -36,6 +37,9 @@ var values_UAVIONIX_ADSB_OUT_DYNAMIC_STATE = map[string]UAVIONIX_ADSB_OUT_DYNAMI
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_OUT_DYNAMIC_STATE) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 5; i++ {
 		mask := UAVIONIX_ADSB_OUT_DYNAMIC_STATE(1 << i)
@@ -53,6 +57,8 @@ func (e *UAVIONIX_ADSB_OUT_DYNAMIC_STATE) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_UAVIONIX_ADSB_OUT_DYNAMIC_STATE[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= UAVIONIX_ADSB_OUT_DYNAMIC_STATE(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_out_rf_select.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_out_rf_select.go
@@ -4,6 +4,7 @@ package uavionix
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -30,6 +31,9 @@ var values_UAVIONIX_ADSB_OUT_RF_SELECT = map[string]UAVIONIX_ADSB_OUT_RF_SELECT{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_OUT_RF_SELECT) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 3; i++ {
 		mask := UAVIONIX_ADSB_OUT_RF_SELECT(1 << i)
@@ -47,6 +51,8 @@ func (e *UAVIONIX_ADSB_OUT_RF_SELECT) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_UAVIONIX_ADSB_OUT_RF_SELECT[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= UAVIONIX_ADSB_OUT_RF_SELECT(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}

--- a/pkg/dialects/uavionix/enum_uavionix_adsb_rf_health.go
+++ b/pkg/dialects/uavionix/enum_uavionix_adsb_rf_health.go
@@ -4,6 +4,7 @@ package uavionix
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -33,6 +34,9 @@ var values_UAVIONIX_ADSB_RF_HEALTH = map[string]UAVIONIX_ADSB_RF_HEALTH{
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (e UAVIONIX_ADSB_RF_HEALTH) MarshalText() ([]byte, error) {
+	if e == 0 {
+		return []byte("0"), nil
+	}
 	var names []string
 	for i := 0; i < 4; i++ {
 		mask := UAVIONIX_ADSB_RF_HEALTH(1 << i)
@@ -50,6 +54,8 @@ func (e *UAVIONIX_ADSB_RF_HEALTH) UnmarshalText(text []byte) error {
 	for _, label := range labels {
 		if value, ok := values_UAVIONIX_ADSB_RF_HEALTH[label]; ok {
 			mask |= value
+		} else if value, err := strconv.Atoi(label); err == nil {
+			mask |= UAVIONIX_ADSB_RF_HEALTH(value)
 		} else {
 			return fmt.Errorf("invalid label '%s'", label)
 		}


### PR DESCRIPTION
Before this PR, attempting to marshal an invalid enum value would return an error.

This PR allows invalid enum values to be marshaled and unmarshaled as ints. In addition, empty bitmasks are now marshaled as `"0"` instead of an empty string.
