### PR TITLE
re-compute checksum of frames without empty byte truncation (bluenviron/mavp2p#59)

### DIFF
--- a/pkg/frame/reader.go
+++ b/pkg/frame/reader.go
@@ -17,6 +17,20 @@ const (
 // 1st January 2015 GMT
 var signatureReferenceDate = time.Date(2015, 0o1, 0o1, 0, 0, 0, 0, time.UTC)
 
+func hasEmptyBytes(buf []byte) bool {
+	return len(buf) > 1 && buf[len(buf)-1] == 0x00
+}
+
+func removeEmptyBytes(buf []byte) []byte {
+	// even with truncation, message length must be at least 1 byte
+	// https://github.com/mavlink/c_library_v2/blob/7ea034366ee7f09f3991a5b82f51f0c259023b38/mavlink_helpers.h#L113
+	end := len(buf)
+	for end > 1 && buf[end-1] == 0x00 {
+		end--
+	}
+	return buf[:end]
+}
+
 // ReadError is the error returned in case of non-fatal parsing errors.
 type ReadError struct {
 	str string
@@ -160,16 +174,29 @@ func (r *Reader) Read() (Frame, error) {
 			}
 
 			_, isV2 := f.(*V2Frame)
-			msg, err := mp.Read(f.GetMessage().(*message.MessageRaw), isV2)
+			rawMessage := f.GetMessage().(*message.MessageRaw)
+
+			msg, err := mp.Read(rawMessage, isV2)
 			if err != nil {
 				return nil, newError("unable to decode message: %s", err.Error())
 			}
 
-			switch ff := f.(type) {
+			switch f := f.(type) {
 			case *V1Frame:
-				ff.Message = msg
+				f.Message = msg
 			case *V2Frame:
-				ff.Message = msg
+				// Some libraries generate messages without removing trailing empty bytes.
+				// The specification says that we must support these messages (and we are)
+				// but there might be troubles when re-encoding them, since checksum is different.
+				// remove trailing empty bytes and re-compute the checksum.
+				// https://mavlink.io/en/guide/serialization.html#payload_truncation
+				// https://github.com/mavlink/rust-mavlink/issues/188#issuecomment-1670605245
+				if isV2 && hasEmptyBytes(rawMessage.Payload) {
+					rawMessage.Payload = removeEmptyBytes(rawMessage.Payload)
+					f.Checksum = f.GenerateChecksum(mp.CRCExtra())
+				}
+
+				f.Message = msg
 			}
 		}
 	}

--- a/pkg/frame/writer_test.go
+++ b/pkg/frame/writer_test.go
@@ -23,6 +23,10 @@ func TestWriterNewErrors(t *testing.T) {
 
 func TestWriterWrite(t *testing.T) {
 	for _, ca := range casesReadWrite {
+		if ca.name == "v2 frame with missing empty byte truncation" {
+			continue
+		}
+
 		t.Run(ca.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			writer, err := NewWriter(WriterConf{


### PR DESCRIPTION

Fixes https://github.com/bluenviron/mavp2p/issues/59