### PR TITLE
support messages with junk after string termination (bluenviron/mavp2p#120)

### DIFF
--- a/pkg/frame/writer_test.go
+++ b/pkg/frame/writer_test.go
@@ -23,7 +23,9 @@ func TestWriterNewErrors(t *testing.T) {
 
 func TestWriterWrite(t *testing.T) {
 	for _, ca := range casesReadWrite {
-		if ca.name == "v2 frame with missing empty byte truncation" {
+		switch ca.name {
+		case "v2 frame with missing empty byte truncation",
+			"v1 frame with junk after string termination":
 			continue
 		}
 


### PR DESCRIPTION
Fixes bluenviron/mavp2p#120

recompute checksum of these messages