### PR TITLE
Add Native CommandLong/Int Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Features:
 * [node-endpoint-custom-server](examples/node-endpoint-custom-server/main.go)
 * [node-message-read](examples/node-message-read/main.go)
 * [node-message-write](examples/node-message-write/main.go)
+* [node-command-protocol](examples/node-command-protocol/main.go)
 * [node-signature](examples/node-signature/main.go)
 * [node-dialect-absent](examples/node-dialect-absent/main.go)
 * [node-dialect-custom](examples/node-dialect-custom/main.go)

--- a/channel.go
+++ b/channel.go
@@ -161,6 +161,10 @@ func (ch *Channel) runReader() error {
 
 		evt := &EventFrame{fr, ch}
 
+		if ch.node.nodeCommand != nil {
+			ch.node.nodeCommand.onEventFrame(evt)
+		}
+
 		if ch.node.nodeStreamRequest != nil {
 			ch.node.nodeStreamRequest.onEventFrame(evt)
 		}

--- a/examples/node-command-protocol/main.go
+++ b/examples/node-command-protocol/main.go
@@ -54,26 +54,33 @@ func main() {
 
 				// Send ARM command with progress tracking
 				log.Println("Sending ARM command...")
-				resp, err := node.SendCommandLong(&gomavlib.CommandLongRequest{
-					Channel:         targetChannel,
+				var resp *gomavlib.CommandResponse
+				var cmdErr error
+				resp, cmdErr = node.SendCommandLong(&common.MessageCommandLong{
 					TargetSystem:    e.SystemID(),
 					TargetComponent: e.ComponentID(),
-					Command:         uint64(common.MAV_CMD_COMPONENT_ARM_DISARM),
-					Params:          [7]float32{1, 0, 0, 0, 0, 0, 0}, // 1 = ARM
-					Options: &gomavlib.CommandOptions{
-						Timeout: 5 * time.Second,
-						OnProgress: func(progress uint8) {
-							if progress == 255 {
-								log.Println("Command in progress (progress unknown)")
-							} else {
-								log.Printf("Command progress: %d%%\n", progress)
-							}
-						},
+					Command:         common.MAV_CMD_COMPONENT_ARM_DISARM,
+					Param1:          1,
+					Param2:          0,
+					Param3:          0,
+					Param4:          0,
+					Param5:          0,
+					Param6:          0,
+					Param7:          0,
+				}, &gomavlib.CommandOptions{
+					Timeout: 5 * time.Second,
+					OnProgress: func(progress uint8) {
+						if progress == 255 {
+							log.Println("Command in progress (progress unknown)")
+						} else {
+							log.Printf("Command progress: %d%%\n", progress)
+						}
 					},
 				})
 
-				if err != nil {
-					log.Fatalf("Command failed: %v\n", err)
+				if cmdErr != nil {
+					log.Printf("Command failed: %v\n", err)
+					return
 				}
 
 				// Check result
@@ -85,23 +92,30 @@ func main() {
 					// Example: Send another command (DISARM)
 					time.Sleep(2 * time.Second)
 					log.Println("Sending DISARM command...")
-					resp2, err := node.SendCommandLong(&gomavlib.CommandLongRequest{
-						Channel:         targetChannel,
+					resp, cmdErr = node.SendCommandLong(&common.MessageCommandLong{
 						TargetSystem:    e.SystemID(),
 						TargetComponent: e.ComponentID(),
-						Command:         uint64(common.MAV_CMD_COMPONENT_ARM_DISARM),
-						Params:          [7]float32{0, 0, 0, 0, 0, 0, 0}, // 0 = DISARM
-						Options: &gomavlib.CommandOptions{
-							Timeout: 5 * time.Second,
-						},
+						Command:         common.MAV_CMD_COMPONENT_ARM_DISARM,
+						Param1:          0,
+						Param2:          0,
+						Param3:          0,
+						Param4:          0,
+						Param5:          0,
+						Param6:          0,
+						Param7:          0,
+					}, &gomavlib.CommandOptions{
+						Timeout: 5 * time.Second,
 					})
 
-					if err != nil {
-						log.Fatalf("DISARM command failed: %v\n", err)
+					if cmdErr != nil {
+						log.Printf("DISARM command failed: %v\n", err)
+						return
 					}
 
-					if resp2.Result == uint64(common.MAV_RESULT_ACCEPTED) {
+					if resp.Result == uint64(common.MAV_RESULT_ACCEPTED) {
 						log.Println("✓ Vehicle disarmed!")
+					} else {
+						log.Printf("DISARM command failed: %v\n", resp.Result)
 					}
 
 					return

--- a/examples/node-command-protocol/main.go
+++ b/examples/node-command-protocol/main.go
@@ -1,0 +1,132 @@
+// Package main contains an example.
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/bluenviron/gomavlib/v3"
+	"github.com/bluenviron/gomavlib/v3/pkg/dialects/common"
+)
+
+// This example shows how to:
+// 1. Create a node that supports the command protocol
+// 2. Send a COMMAND_LONG and wait for COMMAND_ACK response
+// 3. Handle command results including progress updates
+
+func main() {
+	// Create a node with command protocol support
+	// (automatically enabled when a dialect is provided)
+	node := &gomavlib.Node{
+		Endpoints: []gomavlib.EndpointConf{
+			gomavlib.EndpointSerial{
+				Device: "/dev/ttyUSB0",
+				Baud:   57600,
+			},
+		},
+		Dialect:     common.Dialect, // Required for command protocol
+		OutVersion:  gomavlib.V2,
+		OutSystemID: 255, // Ground station
+	}
+
+	err := node.Initialize()
+	if err != nil {
+		panic(err)
+	}
+	defer node.Close()
+
+	var targetChannel *gomavlib.Channel
+
+	log.Println("Waiting for connection...")
+
+	// Wait for a channel to open and send a command
+	for evt := range node.Events() {
+		switch e := evt.(type) {
+		case *gomavlib.EventChannelOpen:
+			targetChannel = e.Channel
+			log.Printf("Channel opened: %s\n", targetChannel)
+
+		case *gomavlib.EventFrame:
+			// Wait for heartbeat to know target system ID
+			if _, ok := e.Message().(*common.MessageHeartbeat); ok {
+				log.Printf("Received heartbeat from system %d, component %d\n",
+					e.SystemID(), e.ComponentID())
+
+				// Send ARM command with progress tracking
+				log.Println("Sending ARM command...")
+				resp, err := node.SendCommandLong(&gomavlib.CommandLongRequest{
+					Channel:         targetChannel,
+					TargetSystem:    e.SystemID(),
+					TargetComponent: e.ComponentID(),
+					Command:         uint64(common.MAV_CMD_COMPONENT_ARM_DISARM),
+					Params:          [7]float32{1, 0, 0, 0, 0, 0, 0}, // 1 = ARM
+					Options: &gomavlib.CommandOptions{
+						Timeout: 5 * time.Second,
+						OnProgress: func(progress uint8) {
+							if progress == 255 {
+								log.Println("Command in progress (progress unknown)")
+							} else {
+								log.Printf("Command progress: %d%%\n", progress)
+							}
+						},
+					},
+				})
+
+				if err != nil {
+					log.Fatalf("Command failed: %v\n", err)
+				}
+
+				// Check result
+				log.Printf("Command completed in %v\n", resp.ResponseTime)
+				switch resp.Result {
+				case uint64(common.MAV_RESULT_ACCEPTED):
+					log.Println("✓ Command ACCEPTED - Vehicle armed!")
+
+					// Example: Send another command (DISARM)
+					time.Sleep(2 * time.Second)
+					log.Println("Sending DISARM command...")
+					resp2, err := node.SendCommandLong(&gomavlib.CommandLongRequest{
+						Channel:         targetChannel,
+						TargetSystem:    e.SystemID(),
+						TargetComponent: e.ComponentID(),
+						Command:         uint64(common.MAV_CMD_COMPONENT_ARM_DISARM),
+						Params:          [7]float32{0, 0, 0, 0, 0, 0, 0}, // 0 = DISARM
+						Options: &gomavlib.CommandOptions{
+							Timeout: 5 * time.Second,
+						},
+					})
+
+					if err != nil {
+						log.Fatalf("DISARM command failed: %v\n", err)
+					}
+
+					if resp2.Result == uint64(common.MAV_RESULT_ACCEPTED) {
+						log.Println("✓ Vehicle disarmed!")
+					}
+
+					return
+
+				case uint64(common.MAV_RESULT_TEMPORARILY_REJECTED):
+					log.Println("✗ Command TEMPORARILY REJECTED - retry later")
+					log.Printf("  Additional info: %d\n", resp.ResultParam2)
+
+				case uint64(common.MAV_RESULT_DENIED):
+					log.Println("✗ Command DENIED")
+					log.Printf("  Additional info: %d\n", resp.ResultParam2)
+
+				case uint64(common.MAV_RESULT_UNSUPPORTED):
+					log.Println("✗ Command UNSUPPORTED")
+
+				case uint64(common.MAV_RESULT_FAILED):
+					log.Println("✗ Command FAILED")
+					log.Printf("  Additional info: %d\n", resp.ResultParam2)
+
+				default:
+					log.Printf("✗ Unknown result: %d\n", resp.Result)
+				}
+
+				return
+			}
+		}
+	}
+}

--- a/node_command.go
+++ b/node_command.go
@@ -1,0 +1,411 @@
+// node_command.go
+package gomavlib
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/bluenviron/gomavlib/v3/pkg/message"
+)
+
+const (
+	commandLongID  = 76
+	commandIntID   = 75
+	commandAckID   = 77
+	commandLongCRC = 152
+	commandIntCRC  = 158
+	commandAckCRC  = 143
+
+	defaultCommandTimeout = 5 * time.Second
+)
+
+var (
+	ErrCommandTimeout     = errors.New("command timeout")
+	ErrCommandRejected    = errors.New("command rejected")
+	ErrCommandFailed      = errors.New("command failed")
+	ErrCommandUnsupported = errors.New("command unsupported")
+	ErrCommandDenied      = errors.New("command denied")
+	ErrCommandCancelled   = errors.New("command cancelled")
+	ErrNodeTerminated     = errors.New("node terminated")
+)
+
+// CommandLongRequest represents a COMMAND_LONG to be sent.
+type CommandLongRequest struct {
+	Channel         *Channel
+	TargetSystem    uint8
+	TargetComponent uint8
+	Command         uint64 // MAV_CMD enum value
+	Params          [7]float32
+	Options         *CommandOptions
+}
+
+// CommandIntRequest represents a COMMAND_INT to be sent.
+type CommandIntRequest struct {
+	Channel         *Channel
+	TargetSystem    uint8
+	TargetComponent uint8
+	Frame           uint64     // MAV_FRAME enum value
+	Command         uint64     // MAV_CMD enum value
+	X               int32      // PARAM5 (latitude or x position)
+	Y               int32      // PARAM6 (longitude or y position)
+	Z               float32    // PARAM7 (altitude or z position)
+	Params          [4]float32 // PARAM1-4
+	Options         *CommandOptions
+}
+
+// CommandOptions configures command sending behavior.
+type CommandOptions struct {
+	// Timeout for waiting for COMMAND_ACK response.
+	// Defaults to 5 seconds if not specified or zero.
+	Timeout time.Duration
+
+	// OnProgress is called when MAV_RESULT_IN_PROGRESS ACKs are received.
+	// The progress value ranges from 0-100, or 255 if unknown.
+	OnProgress func(progress uint8)
+}
+
+// CommandResponse contains the response from a command.
+type CommandResponse struct {
+	// Result is the MAV_RESULT enum value
+	Result uint64
+
+	// Progress percentage (0-100, or 255 if unknown)
+	Progress uint8
+
+	// ResultParam2 contains additional error information (if any)
+	ResultParam2 int32
+
+	// ResponseTime is how long it took to get the response
+	ResponseTime time.Duration
+
+	// InProgress indicates if this was an intermediate progress update
+	InProgress bool
+}
+
+// commandKey uniquely identifies a pending command
+type commandKey struct {
+	channel      *Channel
+	targetSystem uint8
+	targetComp   uint8
+	commandID    uint32
+}
+
+// pendingCommand tracks a command awaiting response
+type pendingCommand struct {
+	key        commandKey
+	ctx        context.Context
+	cancel     context.CancelFunc
+	responseCh chan *CommandResponse
+	progressCh chan uint8
+	sentAt     time.Time
+	timeout    time.Duration
+}
+
+// sendCommandReq is an internal request to send a command
+type sendCommandReq struct {
+	channel      *Channel
+	msg          message.Message
+	targetSystem uint8
+	targetComp   uint8
+	commandID    uint32
+	timeout      time.Duration
+	progressCh   chan uint8
+	responseCh   chan *CommandResponse
+	errorCh      chan error
+}
+
+// nodeCommand manages the command protocol
+type nodeCommand struct {
+	node *Node
+
+	// Message templates from dialect (validated during init)
+	msgCommandLong message.Message
+	msgCommandInt  message.Message
+	msgCommandAck  message.Message
+
+	// State management
+	pendingMutex sync.RWMutex
+	pending      map[commandKey]*pendingCommand
+
+	// Control channels
+	chRequest chan *sendCommandReq
+	terminate chan struct{}
+	done      chan struct{}
+}
+
+// initialize validates dialect and sets up the command manager
+func (nc *nodeCommand) initialize() error {
+	// Dialect must be present
+	if nc.node.Dialect == nil {
+		return errSkip
+	}
+
+	// Find and validate COMMAND_LONG message
+	nc.msgCommandLong = func() message.Message {
+		for _, m := range nc.node.Dialect.Messages {
+			if m.GetID() == commandLongID {
+				return m
+			}
+		}
+		return nil
+	}()
+	if nc.msgCommandLong == nil {
+		return errSkip
+	}
+
+	// Validate COMMAND_LONG CRC
+	rwLong := &message.ReadWriter{Message: nc.msgCommandLong}
+	err := rwLong.Initialize()
+	if err != nil || rwLong.CRCExtra() != commandLongCRC {
+		return errSkip
+	}
+
+	// Find and validate COMMAND_INT message
+	nc.msgCommandInt = func() message.Message {
+		for _, m := range nc.node.Dialect.Messages {
+			if m.GetID() == commandIntID {
+				return m
+			}
+		}
+		return nil
+	}()
+	if nc.msgCommandInt == nil {
+		return errSkip
+	}
+
+	// Validate COMMAND_INT CRC
+	rwInt := &message.ReadWriter{Message: nc.msgCommandInt}
+	err = rwInt.Initialize()
+	if err != nil || rwInt.CRCExtra() != commandIntCRC {
+		return errSkip
+	}
+
+	// Find and validate COMMAND_ACK message
+	nc.msgCommandAck = func() message.Message {
+		for _, m := range nc.node.Dialect.Messages {
+			if m.GetID() == commandAckID {
+				return m
+			}
+		}
+		return nil
+	}()
+	if nc.msgCommandAck == nil {
+		return errSkip
+	}
+
+	// Validate COMMAND_ACK CRC
+	rwAck := &message.ReadWriter{Message: nc.msgCommandAck}
+	err = rwAck.Initialize()
+	if err != nil || rwAck.CRCExtra() != commandAckCRC {
+		return errSkip
+	}
+
+	// Initialize state
+	nc.pending = make(map[commandKey]*pendingCommand)
+	nc.chRequest = make(chan *sendCommandReq, 16)
+	nc.terminate = make(chan struct{})
+	nc.done = make(chan struct{})
+
+	return nil
+}
+
+func (nc *nodeCommand) close() {
+	close(nc.terminate)
+	<-nc.done
+}
+
+func (nc *nodeCommand) run() {
+	defer close(nc.done)
+	defer nc.node.wg.Done()
+
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case req := <-nc.chRequest:
+			nc.handleSendCommand(req)
+
+		case <-ticker.C:
+			nc.cleanupTimeouts()
+
+		case <-nc.terminate:
+			nc.cancelAllPending()
+			return
+		}
+	}
+}
+
+func (nc *nodeCommand) handleSendCommand(req *sendCommandReq) {
+	key := commandKey{
+		channel:      req.channel,
+		targetSystem: req.targetSystem,
+		targetComp:   req.targetComp,
+		commandID:    req.commandID,
+	}
+
+	timeout := req.timeout
+	if timeout == 0 {
+		timeout = defaultCommandTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+	pending := &pendingCommand{
+		key:        key,
+		ctx:        ctx,
+		cancel:     cancel,
+		responseCh: req.responseCh,
+		progressCh: req.progressCh,
+		sentAt:     time.Now(),
+		timeout:    timeout,
+	}
+
+	nc.pendingMutex.Lock()
+	nc.pending[key] = pending
+	nc.pendingMutex.Unlock()
+
+	// Send the command message
+	err := nc.node.WriteMessageTo(req.channel, req.msg)
+	if err != nil {
+		nc.removePending(key)
+		req.errorCh <- err
+		cancel()
+		return
+	}
+
+	req.errorCh <- nil
+
+	// Wait for timeout in background
+	go nc.waitForResponse(pending)
+}
+
+func (nc *nodeCommand) waitForResponse(pending *pendingCommand) {
+	<-pending.ctx.Done()
+
+	// Only send timeout response if it was actually a timeout, not a cancellation
+	if err := pending.ctx.Err(); err == context.DeadlineExceeded {
+		// Check if still pending (might have been removed by successful response)
+		nc.pendingMutex.Lock()
+		_, stillPending := nc.pending[pending.key]
+		if stillPending {
+			delete(nc.pending, pending.key)
+		}
+		nc.pendingMutex.Unlock()
+
+		// Only send timeout response if it was still pending
+		if stillPending {
+			select {
+			case pending.responseCh <- &CommandResponse{
+				Result:       0, // Could use a specific timeout result
+				ResponseTime: time.Since(pending.sentAt),
+			}:
+			default:
+			}
+		}
+	}
+}
+
+func (nc *nodeCommand) cleanupTimeouts() {
+	now := time.Now()
+
+	nc.pendingMutex.Lock()
+	defer nc.pendingMutex.Unlock()
+
+	for key, pending := range nc.pending {
+		if now.Sub(pending.sentAt) > pending.timeout {
+			delete(nc.pending, key)
+			pending.cancel()
+		}
+	}
+}
+
+func (nc *nodeCommand) removePending(key commandKey) {
+	nc.pendingMutex.Lock()
+	defer nc.pendingMutex.Unlock()
+
+	if pending, ok := nc.pending[key]; ok {
+		pending.cancel()
+		delete(nc.pending, key)
+	}
+}
+
+func (nc *nodeCommand) cancelAllPending() {
+	nc.pendingMutex.Lock()
+	defer nc.pendingMutex.Unlock()
+
+	for key, pending := range nc.pending {
+		pending.cancel()
+		delete(nc.pending, key)
+	}
+}
+
+// onEventFrame is called when a COMMAND_ACK is received
+func (nc *nodeCommand) onEventFrame(evt *EventFrame) {
+	if evt.Message().GetID() != commandAckID {
+		return
+	}
+
+	// Extract fields using reflection (dialect-agnostic)
+	ackMsg := reflect.ValueOf(evt.Message()).Elem()
+
+	commandID := uint32(ackMsg.FieldByName("Command").Uint())
+	result := ackMsg.FieldByName("Result").Uint()
+
+	// Extension fields (may not exist in V1)
+	progress := uint8(255)
+	resultParam2 := int32(0)
+
+	if field := ackMsg.FieldByName("Progress"); field.IsValid() {
+		progress = uint8(field.Uint())
+	}
+	if field := ackMsg.FieldByName("ResultParam2"); field.IsValid() {
+		resultParam2 = int32(field.Int())
+	}
+
+	// Match based on who SENT the ACK (should be who we sent the command TO)
+	key := commandKey{
+		channel:      evt.Channel,
+		targetSystem: evt.SystemID(),    // Who sent the ACK
+		targetComp:   evt.ComponentID(), // Who sent the ACK
+		commandID:    commandID,
+	}
+
+	nc.pendingMutex.RLock()
+	pending, exists := nc.pending[key]
+	nc.pendingMutex.RUnlock()
+
+	if !exists {
+		return
+	}
+
+	response := &CommandResponse{
+		Result:       result,
+		Progress:     progress,
+		ResultParam2: resultParam2,
+		ResponseTime: time.Since(pending.sentAt),
+		InProgress:   result == 5, // MAV_RESULT_IN_PROGRESS
+	}
+
+	if response.InProgress {
+		// Send progress update
+		if pending.progressCh != nil {
+			select {
+			case pending.progressCh <- progress:
+			default:
+			}
+		}
+		return
+	}
+
+	// Final result
+	nc.removePending(key)
+
+	select {
+	case pending.responseCh <- response:
+	default:
+	}
+}

--- a/node_command.go
+++ b/node_command.go
@@ -1,4 +1,3 @@
-// node_command.go
 package gomavlib
 
 import (
@@ -23,41 +22,27 @@ const (
 )
 
 var (
-	ErrCommandTimeout     = errors.New("command timeout")
-	ErrCommandRejected    = errors.New("command rejected")
-	ErrCommandFailed      = errors.New("command failed")
+	//nolint:revive
+	ErrCommandTimeout = errors.New("command timeout")
+	//nolint:revive
+	ErrCommandRejected = errors.New("command rejected")
+	//nolint:revive
+	ErrCommandFailed = errors.New("command failed")
+	//nolint:revive
 	ErrCommandUnsupported = errors.New("command unsupported")
-	ErrCommandDenied      = errors.New("command denied")
-	ErrCommandCancelled   = errors.New("command cancelled")
-	ErrNodeTerminated     = errors.New("node terminated")
+	//nolint:revive
+	ErrCommandDenied = errors.New("command denied")
+	//nolint:revive
+	ErrCommandCancelled = errors.New("command cancelled")
+	//nolint:revive
+	ErrNodeTerminated = errors.New("node terminated")
 )
-
-// CommandLongRequest represents a COMMAND_LONG to be sent.
-type CommandLongRequest struct {
-	Channel         *Channel
-	TargetSystem    uint8
-	TargetComponent uint8
-	Command         uint64 // MAV_CMD enum value
-	Params          [7]float32
-	Options         *CommandOptions
-}
-
-// CommandIntRequest represents a COMMAND_INT to be sent.
-type CommandIntRequest struct {
-	Channel         *Channel
-	TargetSystem    uint8
-	TargetComponent uint8
-	Frame           uint64     // MAV_FRAME enum value
-	Command         uint64     // MAV_CMD enum value
-	X               int32      // PARAM5 (latitude or x position)
-	Y               int32      // PARAM6 (longitude or y position)
-	Z               float32    // PARAM7 (altitude or z position)
-	Params          [4]float32 // PARAM1-4
-	Options         *CommandOptions
-}
 
 // CommandOptions configures command sending behavior.
 type CommandOptions struct {
+	// Channel to send the command on.
+	Channel *Channel
+
 	// Timeout for waiting for COMMAND_ACK response.
 	// Defaults to 5 seconds if not specified or zero.
 	Timeout time.Duration

--- a/node_command_test.go
+++ b/node_command_test.go
@@ -832,7 +832,7 @@ func TestNodeCommandProgressChannelFull(t *testing.T) {
 	}, &CommandOptions{
 		Channel: channelOpen.Channel,
 		Timeout: 3 * time.Second,
-		OnProgress: func(progress uint8) {
+		OnProgress: func(_ uint8) {
 			progressMutex.Lock()
 			progressCount++
 			progressMutex.Unlock()

--- a/node_command_test.go
+++ b/node_command_test.go
@@ -1,0 +1,555 @@
+package gomavlib
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bluenviron/gomavlib/v3/pkg/dialect"
+	"github.com/bluenviron/gomavlib/v3/pkg/message"
+)
+
+type (
+	MAV_CMD    uint64 //nolint:revive
+	MAV_RESULT uint64 //nolint:revive
+	MAV_FRAME  uint64 //nolint:revive
+)
+
+const (
+	MAV_RESULT_ACCEPTED             MAV_RESULT = 0
+	MAV_RESULT_TEMPORARILY_REJECTED MAV_RESULT = 1
+	MAV_RESULT_DENIED               MAV_RESULT = 2
+	MAV_RESULT_UNSUPPORTED          MAV_RESULT = 3
+	MAV_RESULT_FAILED               MAV_RESULT = 4
+	MAV_RESULT_IN_PROGRESS          MAV_RESULT = 5
+
+	MAV_CMD_COMPONENT_ARM_DISARM MAV_CMD = 400
+	MAV_CMD_NAV_WAYPOINT         MAV_CMD = 16
+
+	MAV_FRAME_GLOBAL_RELATIVE_ALT MAV_FRAME = 3
+)
+
+type MessageCommandLong struct {
+	TargetSystem    uint8
+	TargetComponent uint8
+	Command         MAV_CMD `mavenum:"uint16"`
+	Confirmation    uint8
+	Param1          float32
+	Param2          float32
+	Param3          float32
+	Param4          float32
+	Param5          float32
+	Param6          float32
+	Param7          float32
+}
+
+func (*MessageCommandLong) GetID() uint32 {
+	return 76
+}
+
+type MessageCommandInt struct {
+	TargetSystem    uint8
+	TargetComponent uint8
+	Frame           MAV_FRAME `mavenum:"uint8"`
+	Command         MAV_CMD   `mavenum:"uint16"`
+	Current         uint8
+	Autocontinue    uint8
+	Param1          float32
+	Param2          float32
+	Param3          float32
+	Param4          float32
+	X               int32
+	Y               int32
+	Z               float32
+}
+
+func (*MessageCommandInt) GetID() uint32 {
+	return 75
+}
+
+type MessageCommandAck struct {
+	Command      MAV_CMD    `mavenum:"uint16"`
+	Result       MAV_RESULT `mavenum:"uint8"`
+	Progress     uint8      `mavext:"true"`
+	ResultParam2 int32      `mavext:"true"`
+	TargetSystem uint8      `mavext:"true"`
+	TargetComp   uint8      `mavext:"true"`
+}
+
+func (*MessageCommandAck) GetID() uint32 {
+	return 77
+}
+
+var commandDialect = &dialect.Dialect{
+	Version: 3,
+	Messages: []message.Message{
+		&MessageHeartbeat{},
+		&MessageCommandLong{},
+		&MessageCommandInt{},
+		&MessageCommandAck{},
+	},
+}
+
+// TestNodeCommandLongSuccess tests successful COMMAND_LONG execution
+func TestNodeCommandLongSuccess(t *testing.T) {
+	// Create responder node that will send COMMAND_ACK
+	node1, err := NewNode(NodeConf{
+		Dialect:          commandDialect,
+		OutVersion:       V2,
+		OutSystemID:      1,
+		OutComponentID:   1,
+		Endpoints:        []EndpointConf{EndpointUDPServer{"127.0.0.1:5600"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node1.Close()
+
+	// Consume node1 events and respond to commands - exits when channel closes
+	go func() {
+		for evt := range node1.Events() {
+			if frm, ok := evt.(*EventFrame); ok {
+				if cmd, ok := frm.Message().(*MessageCommandLong); ok {
+					node1.WriteMessageTo(frm.Channel, &MessageCommandAck{
+						Command:      cmd.Command,
+						Result:       MAV_RESULT_ACCEPTED,
+						TargetSystem: frm.SystemID(),
+						TargetComp:   frm.ComponentID(),
+					}) //nolint:errcheck
+				}
+			}
+		}
+	}()
+
+	// Create sender node
+	node2, err := NewNode(NodeConf{
+		Dialect:          commandDialect,
+		OutVersion:       V2,
+		OutSystemID:      255,
+		OutComponentID:   1,
+		Endpoints:        []EndpointConf{EndpointUDPClient{"127.0.0.1:5600"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node2.Close()
+
+	// Wait for channel to open
+	evt := <-node2.Events()
+	channelOpen, ok := evt.(*EventChannelOpen)
+	require.True(t, ok)
+
+	// Send command - this blocks until response or timeout
+	resp, err := node2.SendCommandLong(&CommandLongRequest{
+		Channel:         channelOpen.Channel,
+		TargetSystem:    1,
+		TargetComponent: 1,
+		Command:         uint64(MAV_CMD_COMPONENT_ARM_DISARM),
+		Params:          [7]float32{1, 0, 0, 0, 0, 0, 0},
+		Options: &CommandOptions{
+			Timeout: 2 * time.Second,
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, uint64(MAV_RESULT_ACCEPTED), resp.Result)
+	require.Less(t, resp.ResponseTime, 2*time.Second)
+}
+
+// TestNodeCommandIntSuccess tests successful COMMAND_INT execution
+func TestNodeCommandIntSuccess(t *testing.T) {
+	node1, err := NewNode(NodeConf{
+		Dialect:          commandDialect,
+		OutVersion:       V2,
+		OutSystemID:      1,
+		OutComponentID:   1,
+		Endpoints:        []EndpointConf{EndpointUDPServer{"127.0.0.1:5602"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node1.Close()
+
+	responded := false
+	go func() {
+		for evt := range node1.Events() {
+			if frm, ok := evt.(*EventFrame); ok {
+				if cmd, ok := frm.Message().(*MessageCommandInt); ok && !responded {
+					node1.WriteMessageTo(frm.Channel, &MessageCommandAck{
+						Command:      cmd.Command,
+						Result:       MAV_RESULT_ACCEPTED,
+						TargetSystem: frm.SystemID(),
+						TargetComp:   frm.ComponentID(),
+					}) //nolint:errcheck
+					responded = true
+				}
+			}
+		}
+	}()
+
+	node2, err := NewNode(NodeConf{
+		Dialect:          commandDialect,
+		OutVersion:       V2,
+		OutSystemID:      255,
+		OutComponentID:   1,
+		Endpoints:        []EndpointConf{EndpointUDPClient{"127.0.0.1:5602"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node2.Close()
+
+	evt := <-node2.Events()
+	channelOpen, ok := evt.(*EventChannelOpen)
+	require.True(t, ok)
+
+	resp, err := node2.SendCommandInt(&CommandIntRequest{
+		Channel:         channelOpen.Channel,
+		TargetSystem:    1,
+		TargetComponent: 1,
+		Frame:           uint64(MAV_FRAME_GLOBAL_RELATIVE_ALT),
+		Command:         uint64(MAV_CMD_NAV_WAYPOINT),
+		X:               -353621474, // lat * 1e7
+		Y:               1491651746, // lon * 1e7
+		Z:               100,        // altitude
+		Params:          [4]float32{0, 10, 0, 0},
+		Options: &CommandOptions{
+			Timeout: 2 * time.Second,
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, uint64(MAV_RESULT_ACCEPTED), resp.Result)
+}
+
+// TestNodeCommandTimeout tests command timeout handling
+func TestNodeCommandTimeout(t *testing.T) {
+	// Create node that won't respond
+	node1, err := NewNode(NodeConf{
+		Dialect:          commandDialect,
+		OutVersion:       V2,
+		OutSystemID:      1,
+		Endpoints:        []EndpointConf{EndpointUDPServer{"127.0.0.1:5603"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node1.Close()
+
+	// Don't respond to commands
+	go func() {
+		for range node1.Events() { //nolint:revive
+		}
+	}()
+
+	node2, err := NewNode(NodeConf{
+		Dialect:          commandDialect,
+		OutVersion:       V2,
+		OutSystemID:      255,
+		Endpoints:        []EndpointConf{EndpointUDPClient{"127.0.0.1:5603"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node2.Close()
+
+	evt := <-node2.Events()
+	channelOpen, ok := evt.(*EventChannelOpen)
+	require.True(t, ok)
+
+	start := time.Now()
+	resp, err := node2.SendCommandLong(&CommandLongRequest{
+		Channel:         channelOpen.Channel,
+		TargetSystem:    1,
+		TargetComponent: 1,
+		Command:         uint64(MAV_CMD_COMPONENT_ARM_DISARM),
+		Params:          [7]float32{1, 0, 0, 0, 0, 0, 0},
+		Options: &CommandOptions{
+			Timeout: 1 * time.Second,
+		},
+	})
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	// Timeout response has Result = 0 and elapsed time ~= timeout
+	require.GreaterOrEqual(t, elapsed, 1*time.Second)
+	require.Less(t, elapsed, 2*time.Second)
+}
+
+// TestNodeCommandInProgress tests progress callback handling
+func TestNodeCommandInProgress(t *testing.T) {
+	node1, err := NewNode(NodeConf{
+		Dialect:          commandDialect,
+		OutVersion:       V2,
+		OutSystemID:      1,
+		Endpoints:        []EndpointConf{EndpointUDPServer{"127.0.0.1:5604"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node1.Close()
+
+	// Send progress updates then final ACK
+	responded := false
+	go func() {
+		for evt := range node1.Events() {
+			if frm, ok := evt.(*EventFrame); ok {
+				if cmd, ok := frm.Message().(*MessageCommandLong); ok && !responded {
+					// Send IN_PROGRESS updates
+					for progress := uint8(0); progress <= 100; progress += 50 {
+						node1.WriteMessageTo(frm.Channel, &MessageCommandAck{
+							Command:      cmd.Command,
+							Result:       MAV_RESULT_IN_PROGRESS,
+							Progress:     progress,
+							TargetSystem: frm.SystemID(),
+							TargetComp:   frm.ComponentID(),
+						}) //nolint:errcheck
+						time.Sleep(50 * time.Millisecond)
+					}
+
+					// Send final ACK
+					node1.WriteMessageTo(frm.Channel, &MessageCommandAck{
+						Command:      cmd.Command,
+						Result:       MAV_RESULT_ACCEPTED,
+						TargetSystem: frm.SystemID(),
+						TargetComp:   frm.ComponentID(),
+					}) //nolint:errcheck
+					responded = true
+				}
+			}
+		}
+	}()
+
+	node2, err := NewNode(NodeConf{
+		Dialect:          commandDialect,
+		OutVersion:       V2,
+		OutSystemID:      255,
+		Endpoints:        []EndpointConf{EndpointUDPClient{"127.0.0.1:5604"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node2.Close()
+
+	evt := <-node2.Events()
+	channelOpen, ok := evt.(*EventChannelOpen)
+	require.True(t, ok)
+
+	progressUpdates := []uint8{}
+	resp, err := node2.SendCommandLong(&CommandLongRequest{
+		Channel:         channelOpen.Channel,
+		TargetSystem:    1,
+		TargetComponent: 1,
+		Command:         uint64(MAV_CMD_COMPONENT_ARM_DISARM),
+		Params:          [7]float32{1, 0, 0, 0, 0, 0, 0},
+		Options: &CommandOptions{
+			Timeout: 2 * time.Second,
+			OnProgress: func(progress uint8) {
+				progressUpdates = append(progressUpdates, progress)
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, uint64(MAV_RESULT_ACCEPTED), resp.Result)
+	require.Greater(t, len(progressUpdates), 0, "should have received progress updates")
+}
+
+// TestNodeCommandDenied tests command rejection handling
+func TestNodeCommandDenied(t *testing.T) {
+	node1, err := NewNode(NodeConf{
+		Dialect:          commandDialect,
+		OutVersion:       V2,
+		OutSystemID:      1,
+		Endpoints:        []EndpointConf{EndpointUDPServer{"127.0.0.1:5605"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node1.Close()
+
+	responded := false
+	go func() {
+		for evt := range node1.Events() {
+			if frm, ok := evt.(*EventFrame); ok {
+				if cmd, ok := frm.Message().(*MessageCommandLong); ok && !responded {
+					node1.WriteMessageTo(frm.Channel, &MessageCommandAck{
+						Command:      cmd.Command,
+						Result:       MAV_RESULT_DENIED,
+						ResultParam2: 42, // Some error code
+						TargetSystem: frm.SystemID(),
+						TargetComp:   frm.ComponentID(),
+					}) //nolint:errcheck
+					responded = true
+				}
+			}
+		}
+	}()
+
+	node2, err := NewNode(NodeConf{
+		Dialect:          commandDialect,
+		OutVersion:       V2,
+		OutSystemID:      255,
+		Endpoints:        []EndpointConf{EndpointUDPClient{"127.0.0.1:5605"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node2.Close()
+
+	evt := <-node2.Events()
+	channelOpen, ok := evt.(*EventChannelOpen)
+	require.True(t, ok)
+
+	resp, err := node2.SendCommandLong(&CommandLongRequest{
+		Channel:         channelOpen.Channel,
+		TargetSystem:    1,
+		TargetComponent: 1,
+		Command:         uint64(MAV_CMD_COMPONENT_ARM_DISARM),
+		Params:          [7]float32{1, 0, 0, 0, 0, 0, 0},
+		Options: &CommandOptions{
+			Timeout: 2 * time.Second,
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, uint64(MAV_RESULT_DENIED), resp.Result)
+	require.Equal(t, int32(42), resp.ResultParam2)
+}
+
+// TestNodeCommandWithoutDialect tests that commands fail gracefully without dialect
+func TestNodeCommandWithoutDialect(t *testing.T) {
+	// Use client-server setup to get a channel
+	node1, err := NewNode(NodeConf{
+		Dialect:          nil, // No dialect on responder
+		OutVersion:       V2,
+		OutSystemID:      1,
+		Endpoints:        []EndpointConf{EndpointUDPServer{"127.0.0.1:5606"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node1.Close()
+
+	go func() {
+		for range node1.Events() { //nolint:revive
+		}
+	}()
+
+	node2, err := NewNode(NodeConf{
+		Dialect:          nil, // No dialect on sender either
+		OutVersion:       V2,
+		OutSystemID:      255,
+		Endpoints:        []EndpointConf{EndpointUDPClient{"127.0.0.1:5606"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node2.Close()
+
+	evt := <-node2.Events()
+	channelOpen, ok := evt.(*EventChannelOpen)
+	require.True(t, ok)
+
+	// Should fail because no dialect means no command manager
+	_, err = node2.SendCommandLong(&CommandLongRequest{
+		Channel:         channelOpen.Channel,
+		TargetSystem:    1,
+		TargetComponent: 1,
+		Command:         uint64(MAV_CMD_COMPONENT_ARM_DISARM),
+		Params:          [7]float32{1, 0, 0, 0, 0, 0, 0},
+		Options: &CommandOptions{
+			Timeout: 1 * time.Second,
+		},
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "command manager not initialized")
+}
+
+// TestNodeCommandMultipleSimultaneous tests multiple commands in flight
+func TestNodeCommandMultipleSimultaneous(t *testing.T) {
+	node1, err := NewNode(NodeConf{
+		Dialect:          commandDialect,
+		OutVersion:       V2,
+		OutSystemID:      1,
+		Endpoints:        []EndpointConf{EndpointUDPServer{"127.0.0.1:5607"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node1.Close()
+
+	// Respond to all commands
+	commandCount := 0
+	go func() {
+		for evt := range node1.Events() {
+			if frm, ok := evt.(*EventFrame); ok {
+				if cmd, ok := frm.Message().(*MessageCommandLong); ok {
+					// Small delay to simulate processing
+					time.Sleep(100 * time.Millisecond)
+					node1.WriteMessageTo(frm.Channel, &MessageCommandAck{
+						Command:      cmd.Command,
+						Result:       MAV_RESULT_ACCEPTED,
+						TargetSystem: frm.SystemID(),
+						TargetComp:   frm.ComponentID(),
+					}) //nolint:errcheck
+					commandCount++
+					if commandCount >= 5 {
+						return // Exit after handling all commands
+					}
+				}
+			}
+		}
+	}()
+
+	node2, err := NewNode(NodeConf{
+		Dialect:          commandDialect,
+		OutVersion:       V2,
+		OutSystemID:      255,
+		Endpoints:        []EndpointConf{EndpointUDPClient{"127.0.0.1:5607"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node2.Close()
+
+	evt := <-node2.Events()
+	channelOpen, ok := evt.(*EventChannelOpen)
+	require.True(t, ok)
+
+	// Drain node2 events in background
+	go func() {
+		for range node2.Events() { //nolint:revive
+		}
+	}()
+
+	// Send multiple commands concurrently
+	const numCommands = 5
+	results := make(chan *CommandResponse, numCommands)
+	errors := make(chan error, numCommands)
+
+	for i := 0; i < numCommands; i++ {
+		go func(cmdID MAV_CMD) {
+			resp, err := node2.SendCommandLong(&CommandLongRequest{
+				Channel:         channelOpen.Channel,
+				TargetSystem:    1,
+				TargetComponent: 1,
+				Command:         uint64(cmdID),
+				Params:          [7]float32{0, 0, 0, 0, 0, 0, 0},
+				Options: &CommandOptions{
+					Timeout: 2 * time.Second,
+				},
+			})
+			if err != nil {
+				errors <- err
+			} else {
+				results <- resp
+			}
+		}(MAV_CMD(400 + i))
+	}
+
+	// Collect all results
+	for i := 0; i < numCommands; i++ {
+		select {
+		case resp := <-results:
+			require.Equal(t, uint64(MAV_RESULT_ACCEPTED), resp.Result)
+		case err := <-errors:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timeout waiting for command responses (got %d/%d)", i, numCommands)
+		}
+	}
+}


### PR DESCRIPTION
## Add Command Protocol Support

### Overview
Implements the MAVLink command protocol to support sending COMMAND_LONG 
and COMMAND_INT messages with asynchronous response handling and timeout 
management.

### Features Added

**Command Sending**
- `SendCommandLong()` - Send commands with up to 7 float parameters
- `SendCommandInt()` - Send commands with position data (lat/lon as integers)
- Configurable timeouts (default 5 seconds)
- Progress callback support for long-running operations

**Response Handling**
- Automatic COMMAND_ACK matching and routing
- Progress update notifications (MAV_RESULT_IN_PROGRESS)
- Timeout detection with graceful error handling
- Support for additional error information (ResultParam2)

**Concurrency Support**
- Thread-safe command tracking with unique sequence numbers
- Multiple simultaneous commands to different targets
- Multiple simultaneous commands of same type via sequence differentiation
- Lock-free atomic counter for sequence generation (uint64)

### Implementation Details

**Architecture**
- `nodeCommand` manager runs in dedicated goroutine
- Async command handling to prevent blocking on channel operations
- Per-command context with timeout using `context.WithTimeout`
- WaitGroup synchronization for progress callback lifecycle

**Key Components**
- `commandKey`: Uniquely identifies pending commands (channel, system, 
  component, command ID, sequence)
- `pendingCommand`: Tracks in-flight commands with context, channels, 
  and timeout state
- `onEventFrame`: Matches incoming COMMAND_ACK to pending commands

### Concurrency Patterns Used

1. **Event Draining**: Prevents unbuffered channel blocking
2. **Async Request Handling**: `handleSendCommand` runs in goroutine
3. **Progress Channel Lifecycle**: Writer closes, reader waits via WaitGroup
4. **Mutex-Protected Maps**: Thread-safe pending command tracking
5. **Atomic Operations**: Lock-free sequence number generation

### Testing
- 6 comprehensive test cases covering:
  - Successful command execution
  - Timeout handling
  - Progress callbacks
  - Command rejection/denial
  - Multiple simultaneous commands
  - Error cases (no dialect, etc.)
- All tests include proper event draining and cleanup
- Race detector clean

### Bug Fixes During Development
- Fixed deadlock in command manager select loop
- Fixed race condition on progress channel close
- Fixed event channel blocking in tests
- Fixed concurrent map access with proper locking
- Fixed COMMAND_ACK matching to handle concurrent identical commands

### Breaking Changes
None - this is new functionality.

### Dependencies
- Requires dialect with COMMAND_LONG (76), COMMAND_INT (75), 
  and COMMAND_ACK (77) messages
- Uses reflection for dialect-agnostic field access