### PR TITLE
add node-command-microservice example (#209) (#218)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Features:
 
 * Create Mavlink nodes able to communicate with other nodes.
   * Supported transports: serial, UDP (server, client or broadcast mode), TCP (server or client mode), custom reader/writer.
+  * Support both domain names and IPs.
   * Emit heartbeats automatically.
   * Send automatic stream requests to Ardupilot devices (disabled by default).
-  * Use both domain names and IPs.
 * Decode and encode Mavlink v2.0 and v1.0.
   * Compute and validate checksums.
   * Support all v2 features: empty-byte truncation, signatures, message extensions.
@@ -68,6 +68,7 @@ Features:
 * [node-endpoint-custom-server](examples/node-endpoint-custom-server/main.go)
 * [node-message-read](examples/node-message-read/main.go)
 * [node-message-write](examples/node-message-write/main.go)
+* [node-command-microservice](examples/node-command-microservice/main.go)
 * [node-signature](examples/node-signature/main.go)
 * [node-dialect-absent](examples/node-dialect-absent/main.go)
 * [node-dialect-custom](examples/node-dialect-custom/main.go)

--- a/events.go
+++ b/events.go
@@ -10,14 +10,14 @@ type Event interface {
 	isEventOut()
 }
 
-// EventChannelOpen is the event fired when a channel gets opened.
+// EventChannelOpen is fired when a channel is opened.
 type EventChannelOpen struct {
 	Channel *Channel
 }
 
 func (*EventChannelOpen) isEventOut() {}
 
-// EventChannelClose is the event fired when a channel gets closed.
+// EventChannelClose is fired when a channel is closed.
 type EventChannelClose struct {
 	Channel *Channel
 	Error   error
@@ -25,7 +25,7 @@ type EventChannelClose struct {
 
 func (*EventChannelClose) isEventOut() {}
 
-// EventFrame is the event fired when a frame is received.
+// EventFrame is fired when a frame is received.
 type EventFrame struct {
 	// frame
 	Frame frame.Frame
@@ -51,7 +51,7 @@ func (res *EventFrame) Message() message.Message {
 	return res.Frame.GetMessage()
 }
 
-// EventParseError is the event fired when a parse error occurs.
+// EventParseError is fired when a parse error occurs.
 type EventParseError struct {
 	// error
 	Error error
@@ -62,12 +62,14 @@ type EventParseError struct {
 
 func (*EventParseError) isEventOut() {}
 
-// EventStreamRequested is the event fired when an automatic stream request is sent.
+// EventStreamRequested is fired when an automatic stream request is sent.
 type EventStreamRequested struct {
 	// channel to which the stream request is addressed
 	Channel *Channel
+
 	// system id to which the stream requests is addressed
 	SystemID byte
+
 	// component id to which the stream requests is addressed
 	ComponentID byte
 }

--- a/examples/node-command-microservice/main.go
+++ b/examples/node-command-microservice/main.go
@@ -1,0 +1,160 @@
+// Package main contains an example.
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/bluenviron/gomavlib/v3"
+	"github.com/bluenviron/gomavlib/v3/pkg/dialects/common"
+)
+
+// This example shows how to:
+// 1. Create a node that supports the command microservice
+// 2. Send a COMMAND_LONG and wait for COMMAND_ACK response
+// 3. Handle command results including progress updates
+
+func waitForHeartbeat(node *gomavlib.Node) (*gomavlib.Channel, uint8, uint8) {
+	for {
+		evt := <-node.Events()
+
+		if evt, ok := evt.(*gomavlib.EventFrame); ok {
+			if _, ok = evt.Message().(*common.MessageHeartbeat); ok {
+				return evt.Channel, evt.SystemID(), evt.ComponentID()
+			}
+		}
+	}
+}
+
+func writeAndWaitCommandLong(
+	node *gomavlib.Node,
+	channel *gomavlib.Channel,
+	cmd *common.MessageCommandLong,
+	timeout time.Duration,
+) error {
+	err := node.WriteMessageTo(channel, cmd)
+	if err != nil {
+		return err
+	}
+
+	t := time.NewTimer(timeout)
+	defer t.Stop()
+
+	for {
+		select {
+		case evt := <-node.Events():
+			if evt, ok := evt.(*gomavlib.EventFrame); ok {
+				if ack, ok2 := evt.Message().(*common.MessageCommandAck); ok2 {
+					if ack.Command == cmd.Command &&
+						evt.SystemID() == cmd.TargetSystem &&
+						evt.ComponentID() == cmd.TargetComponent {
+						switch {
+						case ack.Result == common.MAV_RESULT_IN_PROGRESS:
+							log.Printf("command progress: %d%%\n", ack.Progress)
+
+						case ack.Result != common.MAV_RESULT_ACCEPTED:
+							return fmt.Errorf("command failed with state %v", ack.Result)
+
+						default:
+							return nil
+						}
+					}
+				}
+			}
+
+		case <-t.C:
+			return fmt.Errorf("command timed out")
+		}
+	}
+}
+
+func sleepWhileListening(node *gomavlib.Node, d time.Duration) {
+	t := time.NewTimer(d)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-node.Events():
+		case <-t.C:
+			return
+		}
+	}
+}
+
+func main() {
+	node := &gomavlib.Node{
+		Endpoints: []gomavlib.EndpointConf{
+			gomavlib.EndpointSerial{
+				Device: "/dev/ttyUSB0",
+				Baud:   57600,
+			},
+		},
+		Dialect:     common.Dialect,
+		OutVersion:  gomavlib.V2,
+		OutSystemID: 255, // Ground station
+	}
+
+	err := node.Initialize()
+	if err != nil {
+		panic(err)
+	}
+	defer node.Close()
+
+	log.Println("waiting for a heartbeat...")
+
+	heartbeatChan, heartbeatSystemID, heartbeatComponentID := waitForHeartbeat(node)
+
+	log.Printf("received heartbeat from system %d, component %d\n",
+		heartbeatSystemID, heartbeatComponentID)
+
+	log.Println("Sending ARM command...")
+
+	err = writeAndWaitCommandLong(node,
+		heartbeatChan,
+		&common.MessageCommandLong{
+			TargetSystem:    heartbeatSystemID,
+			TargetComponent: heartbeatComponentID,
+			Command:         common.MAV_CMD_COMPONENT_ARM_DISARM,
+			Param1:          1,
+			Param2:          0,
+			Param3:          0,
+			Param4:          0,
+			Param5:          0,
+			Param6:          0,
+			Param7:          0,
+		},
+		5*time.Second,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	log.Printf("command succeeded")
+
+	sleepWhileListening(node, 2*time.Second)
+
+	log.Println("Sending DISARM command...")
+
+	err = writeAndWaitCommandLong(node,
+		heartbeatChan,
+		&common.MessageCommandLong{
+			TargetSystem:    heartbeatSystemID,
+			TargetComponent: heartbeatComponentID,
+			Command:         common.MAV_CMD_COMPONENT_ARM_DISARM,
+			Param1:          0,
+			Param2:          0,
+			Param3:          0,
+			Param4:          0,
+			Param5:          0,
+			Param6:          0,
+			Param7:          0,
+		},
+		5*time.Second,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	log.Printf("command succeeded")
+}

--- a/examples/node-events/main.go
+++ b/examples/node-events/main.go
@@ -34,18 +34,18 @@ func main() {
 	// print incoming events.
 	// gomavlib provides different kinds of events.
 	for evt := range node.Events() {
-		switch ee := evt.(type) {
+		switch evt := evt.(type) {
 		case *gomavlib.EventFrame:
-			log.Printf("frame received: %v\n", ee)
+			log.Printf("frame received: %v\n", evt)
 
 		case *gomavlib.EventParseError:
-			log.Printf("parse error: %v\n", ee)
+			log.Printf("parse error: %v\n", evt)
 
 		case *gomavlib.EventChannelOpen:
-			log.Printf("channel opened: %v\n", ee)
+			log.Printf("channel opened: %v\n", evt)
 
 		case *gomavlib.EventChannelClose:
-			log.Printf("channel closed: %v\n", ee)
+			log.Printf("channel closed: %v\n", evt)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #209 
Replaces #218 

Turned out that adding an example with a couple of utility functions is way more reliable that a dedicated system that messes up with the event queue.