### PR TITLE
Add more details to serial endpoint labels

### DIFF
--- a/endpoint_serial.go
+++ b/endpoint_serial.go
@@ -70,7 +70,7 @@ func (conf EndpointSerial) init(node *Node) (Endpoint, error) {
 				}
 				return &rwcToConn{rwc}, nil
 			},
-			Label: "serial",
+			Label: "serial:" + conf.Device,
 		},
 	}
 	err := e.initialize()


### PR DESCRIPTION
With several serial devices, it is sometimes necessary to understand which one you received a particular event from 