### PR TITLE
frame: fix UDP datagram boundary recovery after parse errors

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -31,6 +31,12 @@ type Channel struct {
 	label    string
 	rwc      io.ReadWriteCloser
 
+	// PacketOriented enables datagram-boundary recovery: after a parse error the
+	// remainder of the current datagram is discarded so the next Read always starts
+	// on a fresh datagram.  Set by channel_provider when the endpoint implements
+	// packetOrientedEndpoint.
+	PacketOriented bool
+
 	ctx          context.Context
 	ctxCancel    func()
 	frameWriter  *frame.ReadWriter
@@ -54,6 +60,7 @@ func (ch *Channel) initialize() error {
 		ByteReadWriter: ch.rwc,
 		DialectRW:      ch.node.dialectRW,
 		InKey:          ch.node.InKey,
+		PacketOriented: ch.PacketOriented,
 	}
 	err = ch.frameWriter.Initialize()
 	if err != nil {
@@ -153,6 +160,9 @@ func (ch *Channel) runReader() error {
 		if err != nil {
 			var eerr frame.ReadError
 			if errors.As(err, &eerr) {
+				if ch.PacketOriented {
+					ch.frameWriter.DiscardBuffered()
+				}
 				ch.node.pushEvent(&EventParseError{err, ch})
 				continue
 			}

--- a/channel_provider.go
+++ b/channel_provider.go
@@ -5,6 +5,15 @@ import (
 	"fmt"
 )
 
+// packetOrientedEndpoint is implemented by endpoints whose connections carry
+// discrete, self-contained packets (e.g. UDP datagrams). When recognised by
+// channelProvider, the resulting Channel gets PacketOriented = true, which
+// causes the frame reader to discard the remainder of a bad datagram after a
+// parse error instead of continuing to scan inside it.
+type packetOrientedEndpoint interface {
+	isPacketOrientedEndpoint() bool
+}
+
 type channelProvider struct {
 	node     *Node
 	endpoint Endpoint
@@ -44,6 +53,9 @@ func (cp *channelProvider) run() {
 			endpoint: cp.endpoint,
 			label:    label,
 			rwc:      rwc,
+		}
+		if poe, ok := cp.endpoint.(packetOrientedEndpoint); ok && poe.isPacketOrientedEndpoint() {
+			ch.PacketOriented = true
 		}
 		err = ch.initialize()
 		if err != nil {

--- a/endpoint_client_test.go
+++ b/endpoint_client_test.go
@@ -1,6 +1,7 @@
 package gomavlib
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -191,6 +192,135 @@ func TestEndpointClient(t *testing.T) {
 				}, evt)
 			}
 		})
+	}
+}
+
+func TestEndpointUDPClientRecoverAfterMalformedDatagram(t *testing.T) {
+	pc, err := net.ListenPacket("udp4", "127.0.0.1:5604")
+	require.NoError(t, err)
+	defer pc.Close()
+
+	var rawFrame bytes.Buffer
+	dialectRW := &dialect.ReadWriter{Dialect: testDialect}
+	err = dialectRW.Initialize()
+	require.NoError(t, err)
+
+	fw := &frame.Writer{
+		ByteWriter: &rawFrame,
+		DialectRW:  dialectRW,
+	}
+	err = fw.Initialize()
+	require.NoError(t, err)
+
+	sw := &streamwriter.Writer{
+		FrameWriter: fw,
+		Version:     streamwriter.V2,
+		SystemID:    11,
+	}
+	err = sw.Initialize()
+	require.NoError(t, err)
+
+	err = sw.Write(&MessageHeartbeat{
+		Type:           6,
+		Autopilot:      5,
+		BaseMode:       4,
+		CustomMode:     3,
+		SystemStatus:   2,
+		MavlinkVersion: 1,
+	})
+	require.NoError(t, err)
+
+	validDatagram := append([]byte(nil), rawFrame.Bytes()...)
+	malformedDatagram := []byte("\x11\x22\x33\x44\x55")
+	serverErr := make(chan error, 1)
+
+	go func() {
+		buf := make([]byte, 2048)
+		n, addr, err2 := pc.ReadFrom(buf)
+		if err2 != nil {
+			serverErr <- err2
+			return
+		}
+		if n <= 0 {
+			serverErr <- fmt.Errorf("empty datagram")
+			return
+		}
+
+		_, err2 = pc.WriteTo(malformedDatagram, addr)
+		if err2 != nil {
+			serverErr <- err2
+			return
+		}
+
+		_, err2 = pc.WriteTo(validDatagram, addr)
+		if err2 != nil {
+			serverErr <- err2
+			return
+		}
+
+		serverErr <- nil
+	}()
+
+	node, err := NewNode(NodeConf{
+		Dialect:          testDialect,
+		OutVersion:       V2,
+		OutSystemID:      10,
+		Endpoints:        []EndpointConf{EndpointUDPClient{"127.0.0.1:5604"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node.Close()
+
+	evt := <-node.Events()
+	require.Equal(t, &EventChannelOpen{
+		Channel: evt.(*EventChannelOpen).Channel,
+	}, evt)
+
+	err = node.WriteMessageAll(&MessageHeartbeat{
+		Type:           1,
+		Autopilot:      2,
+		BaseMode:       3,
+		CustomMode:     6,
+		SystemStatus:   4,
+		MavlinkVersion: 5,
+	})
+	require.NoError(t, err)
+
+	deadline := time.After(2 * time.Second)
+	gotParseError := false
+
+	for {
+		select {
+		case err := <-serverErr:
+			require.NoError(t, err)
+
+		case ev := <-node.Events():
+			switch et := ev.(type) {
+			case *EventParseError:
+				gotParseError = true
+
+			case *EventFrame:
+				require.True(t, gotParseError)
+				require.Equal(t, &frame.V2Frame{
+					SequenceNumber: 0,
+					SystemID:       11,
+					ComponentID:    1,
+					Message: &MessageHeartbeat{
+						Type:           6,
+						Autopilot:      5,
+						BaseMode:       4,
+						CustomMode:     3,
+						SystemStatus:   2,
+						MavlinkVersion: 1,
+					},
+					Checksum: et.Frame.GetChecksum(),
+				}, et.Frame)
+				return
+			}
+
+		case <-deadline:
+			t.Fatalf("did not receive valid frame after malformed UDP datagram")
+		}
 	}
 }
 

--- a/endpoint_udp_client_packet.go
+++ b/endpoint_udp_client_packet.go
@@ -1,0 +1,57 @@
+package gomavlib
+
+import (
+	"context"
+	"net"
+)
+
+// EndpointUDPClientPacket is a UDP client endpoint that treats each incoming
+// UDP datagram as an atomic unit.
+//
+// Unlike EndpointUDPClient (which uses a stream-oriented bufio reader), this
+// endpoint sets PacketOriented = true on the resulting Channel.  After any
+// parse error the frame reader discards the remaining bytes of the malformed
+// datagram before attempting the next read, so a single bad datagram never
+// contaminates parsing of the next one.
+//
+// Use this endpoint when the remote peer is a MAVLink device that sends
+// well-formed datagrams but the link may occasionally deliver corrupted or
+// out-of-order packets (e.g. a radio-link UDP tunnel in a lossy RF channel).
+type EndpointUDPClientPacket struct {
+	// domain name or IP of the server to connect to, example: 1.2.3.4:5600
+	Address string
+}
+
+func (conf EndpointUDPClientPacket) init(node *Node) (Endpoint, error) {
+	e := &endpointClientPacket{
+		conf: conf,
+		endpointClient: &endpointClient{
+			node: node,
+			conf: EndpointCustomClient{
+				Connect: func(ctx context.Context) (net.Conn, error) {
+					return (&net.Dialer{}).DialContext(ctx, "udp4", conf.Address)
+				},
+				Label: "udp:" + conf.Address,
+			},
+		},
+	}
+	err := e.endpointClient.initialize()
+	return e, err
+}
+
+// endpointClientPacket wraps endpointClient and marks itself as
+// packet-oriented so that channelProvider enables per-datagram recovery.
+type endpointClientPacket struct {
+	conf EndpointUDPClientPacket
+	*endpointClient
+}
+
+// Conf returns the EndpointUDPClientPacket configuration.
+func (e *endpointClientPacket) Conf() EndpointConf {
+	return e.conf
+}
+
+// isPacketOrientedEndpoint implements packetOrientedEndpoint.
+func (e *endpointClientPacket) isPacketOrientedEndpoint() bool {
+	return true
+}

--- a/endpoint_udp_client_packet_test.go
+++ b/endpoint_udp_client_packet_test.go
@@ -1,0 +1,151 @@
+package gomavlib
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bluenviron/gomavlib/v3/pkg/dialect"
+	"github.com/bluenviron/gomavlib/v3/pkg/frame"
+	"github.com/bluenviron/gomavlib/v3/pkg/streamwriter"
+)
+
+// buildValidDatagram builds a serialised MAVLink v2 frame for msg via the
+// test dialect and returns the raw bytes suitable for sending as one UDP datagram.
+func buildValidDatagram(t *testing.T, msg *MessageHeartbeat, systemID byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	drw := &dialect.ReadWriter{Dialect: testDialect}
+	require.NoError(t, drw.Initialize())
+
+	fw := &frame.Writer{ByteWriter: &buf, DialectRW: drw}
+	require.NoError(t, fw.Initialize())
+
+	sw := &streamwriter.Writer{
+		FrameWriter: fw,
+		Version:     streamwriter.V2,
+		SystemID:    systemID,
+	}
+	require.NoError(t, sw.Initialize())
+	require.NoError(t, sw.Write(msg))
+
+	return append([]byte(nil), buf.Bytes()...)
+}
+
+// TestEndpointUDPClientPacketRecoverAfterMalformedDatagrams verifies that
+// EndpointUDPClientPacket discards each bad datagram atomically and resumes
+// normal parsing on the next one, without cascading spurious parse errors.
+func TestEndpointUDPClientPacketRecoverAfterMalformedDatagrams(t *testing.T) {
+	pc, err := net.ListenPacket("udp4", "127.0.0.1:5605")
+	require.NoError(t, err)
+	defer pc.Close()
+
+	validData := buildValidDatagram(t, &MessageHeartbeat{
+		Type:           6,
+		Autopilot:      5,
+		BaseMode:       4,
+		CustomMode:     3,
+		SystemStatus:   2,
+		MavlinkVersion: 1,
+	}, 11)
+
+	// Two distinct malformed datagrams.
+	junk1 := []byte("\x11\x22\x33\x44\x55\x66\x77\x88")
+	junk2 := []byte("\xAA\xBB\xCC\xDD\xEE\xFF\x01\x02")
+
+	serverErr := make(chan error, 1)
+
+	go func() {
+		buf := make([]byte, 2048)
+		n, addr, err2 := pc.ReadFrom(buf)
+		if err2 != nil {
+			serverErr <- err2
+			return
+		}
+		if n <= 0 {
+			serverErr <- fmt.Errorf("empty initial datagram")
+			return
+		}
+
+		for _, junk := range [][]byte{junk1, junk2} {
+			if _, err2 = pc.WriteTo(junk, addr); err2 != nil {
+				serverErr <- err2
+				return
+			}
+		}
+
+		if _, err2 = pc.WriteTo(validData, addr); err2 != nil {
+			serverErr <- err2
+			return
+		}
+
+		serverErr <- nil
+	}()
+
+	node, err := NewNode(NodeConf{
+		Dialect:          testDialect,
+		OutVersion:       V2,
+		OutSystemID:      10,
+		Endpoints:        []EndpointConf{EndpointUDPClientPacket{"127.0.0.1:5605"}},
+		HeartbeatDisable: true,
+	})
+	require.NoError(t, err)
+	defer node.Close()
+
+	// Wait for channel open.
+	evt := <-node.Events()
+	_, ok := evt.(*EventChannelOpen)
+	require.True(t, ok)
+
+	// Send one frame to trigger server goroutine.
+	err = node.WriteMessageAll(&MessageHeartbeat{
+		Type: 1, Autopilot: 2, BaseMode: 3,
+		CustomMode: 6, SystemStatus: 4, MavlinkVersion: 5,
+	})
+	require.NoError(t, err)
+
+	deadline := time.After(2 * time.Second)
+	parseErrors := 0
+
+	for {
+		select {
+		case sErr := <-serverErr:
+			require.NoError(t, sErr)
+
+		case ev := <-node.Events():
+			switch et := ev.(type) {
+			case *EventParseError:
+				parseErrors++
+
+			case *EventFrame:
+				// Must have received exactly 2 parse errors (one per junk datagram).
+				require.Equal(t, 2, parseErrors,
+					"expected exactly 2 EventParseError (one per junk datagram), got %d", parseErrors)
+
+				require.Equal(t, &frame.V2Frame{
+					SequenceNumber: 0,
+					SystemID:       11,
+					ComponentID:    1,
+					Message: &MessageHeartbeat{
+						Type:           6,
+						Autopilot:      5,
+						BaseMode:       4,
+						CustomMode:     3,
+						SystemStatus:   2,
+						MavlinkVersion: 1,
+					},
+					Checksum: et.Frame.GetChecksum(),
+				}, et.Frame)
+				return
+			}
+
+		case <-deadline:
+			t.Fatalf("timed out: got %d parse errors, never received valid frame", parseErrors)
+		}
+	}
+}

--- a/pkg/frame/reader.go
+++ b/pkg/frame/reader.go
@@ -116,6 +116,15 @@ func (r *Reader) Initialize() error {
 	return nil
 }
 
+// DiscardBuffered discards all bytes currently buffered but not yet consumed by the parser.
+// Call this after a ReadError to discard the remainder of a malformed UDP datagram and
+// ensure the next Read begins on a fresh datagram boundary.
+func (r *Reader) DiscardBuffered() {
+	if n := r.BufByteReader.Buffered(); n > 0 {
+		_, _ = r.BufByteReader.Discard(n)
+	}
+}
+
 // Read reads a Frame from the reader.
 // It must not be called by multiple routines in parallel.
 func (r *Reader) Read() (Frame, error) {

--- a/pkg/frame/reader_test.go
+++ b/pkg/frame/reader_test.go
@@ -487,3 +487,32 @@ func TestReaderErrorSignatureTimestamp(t *testing.T) {
 	_, err = reader.Read()
 	require.EqualError(t, err, "signature timestamp is too old")
 }
+
+func TestReaderRecoverAfterInvalidV2IncompatibilityFlag(t *testing.T) {
+	stream := []byte("\xFD\x00\xFD\x00\x00\x00\x03\x04\x05\x04\x00\x00\xb7\x0a")
+
+	reader, err := NewReader(ReaderConf{Reader: bytes.NewReader(stream)})
+	require.NoError(t, err)
+
+	_, err = reader.Read()
+	require.EqualError(t, err, "unknown incompatibility flag: 253")
+
+	_, err = reader.Read()
+	require.EqualError(t, err, "invalid magic byte: 0")
+
+	f, err := reader.Read()
+	require.NoError(t, err)
+
+	require.Equal(t, &V2Frame{
+		IncompatibilityFlag: 0,
+		CompatibilityFlag:   0,
+		SequenceNumber:      3,
+		SystemID:            4,
+		ComponentID:         5,
+		Message: &message.MessageRaw{
+			ID:      4,
+			Payload: nil,
+		},
+		Checksum: 0x0ab7,
+	}, f)
+}

--- a/pkg/frame/readwriter.go
+++ b/pkg/frame/readwriter.go
@@ -1,6 +1,7 @@
 package frame
 
 import (
+	"bufio"
 	"io"
 
 	"github.com/bluenviron/gomavlib/v3/pkg/dialect"
@@ -91,17 +92,30 @@ type ReadWriter struct {
 	// Deprecated: use streamwriter.Writer for writing messages.
 	OutKey *V2Key
 
+	// If true, the reader uses a 65536-byte buffer so each underlying Read()
+	// consumes exactly one UDP datagram. Combined with Channel.PacketOriented,
+	// this enables full datagram-boundary recovery after parse errors.
+	PacketOriented bool
+
 	*Reader
 	*Writer
 }
 
 // Initialize initializes ReadWriter.
 func (rw *ReadWriter) Initialize() error {
-	r, err := NewReader(ReaderConf{
-		Reader:    rw.ByteReadWriter,
+	r := &Reader{
 		DialectRW: rw.DialectRW,
 		InKey:     rw.InKey,
-	})
+	}
+	if rw.PacketOriented {
+		// Use a 65536-byte buffer so each underlying Read() consumes exactly one
+		// UDP datagram (max 65535 bytes). Do NOT set ByteReader — Initialize()
+		// would overwrite BufByteReader with a default 512-byte buffer.
+		r.BufByteReader = bufio.NewReaderSize(rw.ByteReadWriter, 65536)
+	} else {
+		r.ByteReader = rw.ByteReadWriter
+	}
+	err := r.Initialize()
 	if err != nil {
 		return err
 	}

--- a/pkg/frame/v2_frame.go
+++ b/pkg/frame/v2_frame.go
@@ -154,7 +154,7 @@ func (f V2Frame) GenerateSignature(key *V2Key) *V2Signature {
 
 func (f *V2Frame) unmarshal(br *bufio.Reader) error {
 	// header
-	buf, err := peekAndDiscard(br, 9)
+	buf, err := br.Peek(9)
 	if err != nil {
 		return err
 	}
@@ -170,6 +170,11 @@ func (f *V2Frame) unmarshal(br *bufio.Reader) error {
 	// discard frame if incompatibility flag is not understood, as in recommendations
 	if f.IncompatibilityFlag != 0 && f.IncompatibilityFlag != V2FlagSigned {
 		return fmt.Errorf("unknown incompatibility flag: %d", f.IncompatibilityFlag)
+	}
+
+	_, err = br.Discard(9)
+	if err != nil {
+		return err
 	}
 
 	// message


### PR DESCRIPTION
## Problem

When using `EndpointUDPClient` over a real UDP link (e.g. a radio-link tunnel), a single malformed or out-of-order datagram produces dozens of spurious `parse error invalid magic byte` errors:

```
2026/04/11 15:55:46 parse error invalid magic byte: 0
2026/04/11 15:55:46 parse error invalid magic byte: ff
2026/04/11 15:55:46 parse error invalid magic byte: 2b
```

The root cause: `bufio.Reader` treats the UDP connection as a byte stream. After a parse error it continues scanning byte-by-byte inside the same datagram, generating one error per remaining byte. The next datagram then starts mid-buffer, corrupting further frames.

This does not affect TCP or serial endpoints because those are true byte streams where byte-by-byte scanning is the correct recovery strategy.

## Solution

Add `EndpointUDPClientPacket` — identical to `EndpointUDPClient` but marks the channel as packet-oriented. After any `ReadError`, `DiscardBuffered()` drops all bytes still buffered from the current datagram so the next `Read()` begins on a fresh UDP packet boundary.

One bad datagram → exactly one `EventParseError` → normal parsing resumes.

## Changes

- `pkg/frame`: add `Reader.DiscardBuffered()` to flush the bufio buffer
- `pkg/frame`: `ReadWriter` allocates a 65536-byte buffer in packet-oriented mode so one bufio fill always covers exactly one datagram
- `pkg/frame/v2_frame`: unmarshal header with `Peek` + `Discard` instead of `peekAndDiscard` so an incompatibility-flag error leaves header bytes in the buffer for `DiscardBuffered` to clean up
- `channel`: call `DiscardBuffered()` on `ReadError` when `PacketOriented`
- `channel_provider`: detect `packetOrientedEndpoint` interface and set the flag
- `endpoint_udp_client_packet`: new `EndpointUDPClientPacket` endpoint type

## Tests

- `TestEndpointUDPClientPacketRecoverAfterMalformedDatagrams`: sends 2 junk datagrams followed by a valid one — verifies exactly 2 `EventParseError` events and correct frame received after
- `TestEndpointUDPClientRecoverAfterMalformedDatagram`: existing-style test in `endpoint_client_test.go`
- `TestReaderRecoverAfterInvalidV2IncompatibilityFlag`: unit test for the `Peek+Discard` header change
