### PR TITLE
remove unmaintained monkey library test dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/bluenviron/gomavlib/v3
 go 1.25.0
 
 require (
-	bou.ke/monkey v1.0.2
 	github.com/alecthomas/kong v1.15.0
 	github.com/pion/transport/v2 v2.2.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
-bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/kong v1.15.0 h1:BVJstKbpO73zKpmIu+m/aLRrNmWwxXPIGTNin9VmLVI=

--- a/pkg/frame/writer.go
+++ b/pkg/frame/writer.go
@@ -99,6 +99,7 @@ type Writer struct {
 	// private
 	//
 
+	now           func() time.Time
 	bw            []byte
 	nextSeqNumber byte
 }
@@ -111,6 +112,10 @@ func (w *Writer) Initialize() error {
 
 	if w.OutComponentID < 1 {
 		w.OutComponentID = 1
+	}
+
+	if w.now == nil {
+		w.now = time.Now
 	}
 
 	w.bw = make([]byte, bufferSize)
@@ -182,7 +187,7 @@ func (w *Writer) writeFrameAndFill(fr Frame) error {
 	if ff, ok := fr.(*V2Frame); ok && w.OutKey != nil {
 		ff.SignatureLinkID = w.OutSignatureLinkID
 		// Timestamp in 10 microsecond units since 1st January 2015 GMT time
-		ff.SignatureTimestamp = uint64(time.Since(signatureReferenceDate)) / 10000
+		ff.SignatureTimestamp = uint64(w.now().Sub(signatureReferenceDate)) / 10000
 		ff.Signature = ff.GenerateSignature(w.OutKey)
 	}
 

--- a/pkg/frame/writer.go
+++ b/pkg/frame/writer.go
@@ -99,7 +99,7 @@ type Writer struct {
 	// private
 	//
 
-	now           func() time.Time
+	timeNow       func() time.Time
 	bw            []byte
 	nextSeqNumber byte
 }
@@ -114,8 +114,8 @@ func (w *Writer) Initialize() error {
 		w.OutComponentID = 1
 	}
 
-	if w.now == nil {
-		w.now = time.Now
+	if w.timeNow == nil {
+		w.timeNow = time.Now
 	}
 
 	w.bw = make([]byte, bufferSize)
@@ -187,7 +187,7 @@ func (w *Writer) writeFrameAndFill(fr Frame) error {
 	if ff, ok := fr.(*V2Frame); ok && w.OutKey != nil {
 		ff.SignatureLinkID = w.OutSignatureLinkID
 		// Timestamp in 10 microsecond units since 1st January 2015 GMT time
-		ff.SignatureTimestamp = uint64(w.now().Sub(signatureReferenceDate)) / 10000
+		ff.SignatureTimestamp = uint64(w.timeNow().Sub(signatureReferenceDate)) / 10000
 		ff.Signature = ff.GenerateSignature(w.OutKey)
 	}
 

--- a/pkg/frame/writer_test.go
+++ b/pkg/frame/writer_test.go
@@ -170,7 +170,7 @@ func TestWriterWriteMessage(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			writer.now = func() time.Time { return wayback }
+			writer.timeNow = func() time.Time { return wayback }
 
 			err = writer.WriteMessage(c.msg)
 			require.NoError(t, err)

--- a/pkg/frame/writer_test.go
+++ b/pkg/frame/writer_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bluenviron/gomavlib/v3/pkg/dialect"
@@ -122,10 +121,7 @@ func TestWriterWriteErrors(t *testing.T) {
 }
 
 func TestWriterWriteMessage(t *testing.T) {
-	// fake current time in order to obtain deterministic signatures
 	wayback := time.Date(2019, time.May, 18, 1, 2, 3, 4, time.UTC)
-	patch := monkey.Patch(time.Now, func() time.Time { return wayback })
-	defer patch.Unpatch()
 
 	for _, c := range []struct {
 		name string
@@ -173,6 +169,8 @@ func TestWriterWriteMessage(t *testing.T) {
 				OutKey:      c.key,
 			})
 			require.NoError(t, err)
+
+			writer.now = func() time.Time { return wayback }
 
 			err = writer.WriteMessage(c.msg)
 			require.NoError(t, err)

--- a/pkg/streamwriter/writer.go
+++ b/pkg/streamwriter/writer.go
@@ -69,6 +69,7 @@ type Writer struct {
 	// private
 	//
 
+	now           func() time.Time
 	nextSeqNumber byte
 }
 
@@ -85,6 +86,10 @@ func (w *Writer) Initialize() error {
 	}
 	if w.Key != nil && w.Version != V2 {
 		return fmt.Errorf("OutKey requires V2 frames")
+	}
+
+	if w.now == nil {
+		w.now = time.Now
 	}
 
 	return nil
@@ -150,7 +155,7 @@ func (w *Writer) writeInner(fr frame.Frame) error {
 	if ff, ok := fr.(*frame.V2Frame); ok && w.Key != nil {
 		ff.SignatureLinkID = w.SignatureLinkID
 		// Timestamp in 10 microsecond units since 1st January 2015 GMT time
-		ff.SignatureTimestamp = uint64(time.Since(signatureReferenceDate)) / 10000
+		ff.SignatureTimestamp = uint64(w.now().Sub(signatureReferenceDate)) / 10000
 		ff.Signature = ff.GenerateSignature(w.Key)
 	}
 

--- a/pkg/streamwriter/writer.go
+++ b/pkg/streamwriter/writer.go
@@ -69,7 +69,7 @@ type Writer struct {
 	// private
 	//
 
-	now           func() time.Time
+	timeNow       func() time.Time
 	nextSeqNumber byte
 }
 
@@ -88,8 +88,8 @@ func (w *Writer) Initialize() error {
 		return fmt.Errorf("OutKey requires V2 frames")
 	}
 
-	if w.now == nil {
-		w.now = time.Now
+	if w.timeNow == nil {
+		w.timeNow = time.Now
 	}
 
 	return nil
@@ -155,7 +155,7 @@ func (w *Writer) writeInner(fr frame.Frame) error {
 	if ff, ok := fr.(*frame.V2Frame); ok && w.Key != nil {
 		ff.SignatureLinkID = w.SignatureLinkID
 		// Timestamp in 10 microsecond units since 1st January 2015 GMT time
-		ff.SignatureTimestamp = uint64(w.now().Sub(signatureReferenceDate)) / 10000
+		ff.SignatureTimestamp = uint64(w.timeNow().Sub(signatureReferenceDate)) / 10000
 		ff.Signature = ff.GenerateSignature(w.Key)
 	}
 

--- a/pkg/streamwriter/writer_test.go
+++ b/pkg/streamwriter/writer_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/bluenviron/gomavlib/v3/pkg/dialect"
 	"github.com/bluenviron/gomavlib/v3/pkg/frame"
 	"github.com/bluenviron/gomavlib/v3/pkg/message"
@@ -70,10 +69,7 @@ func (m *MessageTest8) GetID() uint32 {
 }
 
 func TestWriteMessage(t *testing.T) {
-	// fake current time in order to obtain deterministic signatures
 	wayback := time.Date(2019, time.May, 18, 1, 2, 3, 4, time.UTC)
-	patch := monkey.Patch(time.Now, func() time.Time { return wayback })
-	defer patch.Unpatch()
 
 	for _, ca := range []struct {
 		name string
@@ -127,6 +123,7 @@ func TestWriteMessage(t *testing.T) {
 				SystemID:    1,
 				Key:         ca.key,
 			}
+			nw.now = func() time.Time { return wayback }
 			err = nw.Initialize()
 			require.NoError(t, err)
 

--- a/pkg/streamwriter/writer_test.go
+++ b/pkg/streamwriter/writer_test.go
@@ -123,7 +123,7 @@ func TestWriteMessage(t *testing.T) {
 				SystemID:    1,
 				Key:         ca.key,
 			}
-			nw.now = func() time.Time { return wayback }
+			nw.timeNow = func() time.Time { return wayback }
 			err = nw.Initialize()
 			require.NoError(t, err)
 


### PR DESCRIPTION
Summary

  - Replace bou.ke/monkey with a now func() time.Time field on frame.Writer and streamwriter.Writer
  - bou.ke/monkey is unmaintained and uses assembly-level function patching that only supports amd64 and 386, making it broken on arm64
  - Tests set the now field directly instead of monkey-patching time.Now

The variable indirection doesn't add any overhead.

```go
package streamwriter

import (
    "testing"
    "time"
)

func BenchmarkTimeNowDirect(b *testing.B) {
    for range b.N {
            time.Now()
    }
}

func BenchmarkTimeNowFuncVar(b *testing.B) {
    now := time.Now
    for range b.N {
            now()
    }
}
```
