### PR TITLE
fix reader buffer truncating multi-frame UDP datagrams (#245)

### DIFF
--- a/pkg/frame/reader.go
+++ b/pkg/frame/reader.go
@@ -12,7 +12,13 @@ import (
 )
 
 const (
-	bufferSize = 512 // frames cannot go beyond len(header) + 255 + len(check) + len(sig)
+	// bufferSize is the size of the internal bufio.Reader buffer.
+	// A single MAVLink V2 frame cannot exceed len(magic) + len(header) + 255 + len(check) + len(sig) = 280 bytes,
+	// but UDP transports often pack multiple frames into a single datagram. If the buffer is smaller than the
+	// datagram, the kernel discards the trailing bytes (since each Read() on a UDP socket consumes exactly one
+	// datagram), causing checksum failures and "invalid magic byte" errors on otherwise valid streams.
+	// The maximum UDP payload is 65507 bytes; round up to fit any plausible datagram in a single fill().
+	bufferSize = 65536
 )
 
 // 1st January 2015 GMT

--- a/pkg/frame/reader_test.go
+++ b/pkg/frame/reader_test.go
@@ -3,6 +3,7 @@ package frame
 import (
 	"bytes"
 	"encoding/binary"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -486,4 +487,73 @@ func TestReaderErrorSignatureTimestamp(t *testing.T) {
 
 	_, err = reader.Read()
 	require.EqualError(t, err, "signature timestamp is too old")
+}
+
+// datagramReader mimics the semantics of a UDP net.Conn: each Read() returns
+// exactly one datagram and any leftover bytes that did not fit into the caller's
+// buffer are silently discarded by the kernel, as documented for SOCK_DGRAM.
+type datagramReader struct {
+	datagrams [][]byte
+}
+
+func (d *datagramReader) Read(p []byte) (int, error) {
+	if len(d.datagrams) == 0 {
+		return 0, io.EOF
+	}
+	dg := d.datagrams[0]
+	d.datagrams = d.datagrams[1:]
+	n := copy(p, dg)
+	// emulate the kernel discarding the tail of an oversized datagram.
+	return n, nil
+}
+
+// TestReaderUDPMultiFrameDatagram verifies that the Reader can decode every
+// frame inside a single UDP datagram even when their combined size exceeds the
+// classic MAVLink frame budget. Routers and autopilots (e.g. ArduPilot via
+// mavproxy / mavp2p forwarders) routinely coalesce multiple frames into one
+// datagram, and an undersized internal buffer would cause the kernel to
+// truncate the datagram, producing spurious "invalid magic byte" and
+// "wrong checksum" errors. Regression test for the UDP parsing failure
+// reported against valid ArduPilot streams.
+func TestReaderUDPMultiFrameDatagram(t *testing.T) {
+	// craft three frames whose total encoded length is larger than the
+	// previous internal buffer size (512 bytes).
+	makeFrame := func(seq byte, payloadLen int) ([]byte, *V2Frame) {
+		payload := bytes.Repeat([]byte{0x10}, payloadLen)
+		f := &V2Frame{
+			IncompatibilityFlag: 0,
+			CompatibilityFlag:   0,
+			SequenceNumber:      seq,
+			SystemID:            1,
+			ComponentID:         2,
+			Message: &message.MessageRaw{
+				ID:      0x0607,
+				Payload: payload,
+			},
+		}
+		f.Checksum = f.GenerateChecksum(0)
+		buf := make([]byte, 512)
+		n, err := f.marshalTo(buf, payload)
+		require.NoError(t, err)
+		return buf[:n], f
+	}
+
+	raw1, want1 := makeFrame(1, 250)
+	raw2, want2 := makeFrame(2, 250)
+	raw3, want3 := makeFrame(3, 50)
+
+	// concatenate every frame into a single UDP datagram (>512 bytes).
+	datagram := append(append(append([]byte{}, raw1...), raw2...), raw3...)
+	require.Greater(t, len(datagram), 512)
+
+	reader, err := NewReader(ReaderConf{
+		Reader: &datagramReader{datagrams: [][]byte{datagram}},
+	})
+	require.NoError(t, err)
+
+	for _, want := range []*V2Frame{want1, want2, want3} {
+		got, errR := reader.Read()
+		require.NoError(t, errR)
+		require.Equal(t, want, got)
+	}
 }


### PR DESCRIPTION
Fixes #245.

## Root cause

The `frame.Reader` wraps its underlying `io.Reader` in a `bufio.Reader` sized to 512 bytes (the maximum length of a single MAVLink V2 frame: `len(magic) + len(header) + 255 + len(check) + len(sig)` ≈ 280, doubled by the original author as a safety margin).

That sizing is fine for stream transports (serial, TCP), but it is wrong for UDP. On UDP the underlying `Read()` consumes exactly one datagram per call, and any bytes that do not fit into the caller's buffer are silently discarded by the kernel (SOCK_DGRAM semantics). ArduPilot, mavp2p, and mavproxy commonly coalesce several MAVLink frames into a single UDP datagram; once the datagram exceeds 512 bytes the trailing bytes are dropped, so the next read picks up a fresh datagram mid-frame and the parser emits the symptoms reported in the issue:

```
wrong checksum, expected 690b, got e1cf, message id is 34
invalid magic byte: b3
```

The same stream works over TCP (no datagram boundaries to lose) and in QGroundControl / MAVProxy (they size their receive buffers for the full UDP MTU), which matches the report.

## Fix

Raise the internal buffer to 65536 bytes so a single `fill()` can hold any plausible UDP datagram (max UDP payload is 65507). The buffer is allocated once per `Reader`, not per packet, so there is no hot-path allocation and no impact on the TCP / serial code paths.

## Test

Added `TestReaderUDPMultiFrameDatagram` in `pkg/frame/reader_test.go`. It uses a small `io.Reader` that mimics UDP semantics (one datagram per `Read`, tail discarded if it does not fit) and feeds the Reader a single datagram containing three V2 frames totalling ~590 bytes. With the previous 512-byte buffer the third frame is corrupted; with the fix all three decode cleanly.