### PR TITLE
minimize errors in UDP connections (#246)

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/bluenviron/gomavlib/v3/pkg/frame"
@@ -12,8 +13,45 @@ import (
 )
 
 const (
-	writeBufferSize = 64
+	writeBufferSize        = 64
+	datagramReadBufferSize = 512
 )
+
+type datagramReader struct {
+	r   io.ReadCloser
+	buf []byte
+	pos int
+}
+
+func (r *datagramReader) ReadPacket() error {
+	if r.buf == nil {
+		r.buf = make([]byte, datagramReadBufferSize)
+	}
+
+	n, err := r.r.Read(r.buf[:datagramReadBufferSize])
+	if n == 0 && err != nil {
+		return err
+	}
+
+	r.buf = r.buf[:n]
+	r.pos = 0
+
+	return nil
+}
+
+func (r *datagramReader) Read(p []byte) (n int, err error) {
+	n = copy(p, r.buf[r.pos:])
+	r.pos += n
+	if n == 0 && r.pos >= len(r.buf) {
+		return 0, fmt.Errorf("packet is too short")
+	}
+	return n, nil
+}
+
+type readWriter struct {
+	io.Reader
+	io.Writer
+}
 
 func randomByte() (byte, error) {
 	var buf [1]byte
@@ -26,16 +64,18 @@ func randomByte() (byte, error) {
 // For instance, a TCP client endpoint creates a single channel, while a TCP
 // server endpoint creates a channel for each incoming connection.
 type Channel struct {
-	node     *Node
-	endpoint Endpoint
-	label    string
-	rwc      io.ReadWriteCloser
+	node       *Node
+	endpoint   Endpoint
+	label      string
+	rwc        io.ReadWriteCloser
+	isDatagram bool
 
-	ctx          context.Context
-	ctxCancel    func()
-	frameWriter  *frame.ReadWriter
-	streamWriter *streamwriter.Writer
-	running      bool
+	datagramReader  *datagramReader
+	ctx             context.Context
+	ctxCancel       func()
+	frameReadWriter *frame.ReadWriter
+	streamWriter    *streamwriter.Writer
+	running         bool
 
 	// in
 	chWrite chan any
@@ -50,18 +90,29 @@ func (ch *Channel) initialize() error {
 		return err
 	}
 
-	ch.frameWriter = &frame.ReadWriter{
-		ByteReadWriter: ch.rwc,
+	var rw io.ReadWriter
+	if ch.isDatagram {
+		ch.datagramReader = &datagramReader{r: ch.rwc}
+		rw = &readWriter{
+			Reader: ch.datagramReader,
+			Writer: ch.rwc,
+		}
+	} else {
+		rw = ch.rwc
+	}
+
+	ch.frameReadWriter = &frame.ReadWriter{
+		ByteReadWriter: rw,
 		DialectRW:      ch.node.dialectRW,
 		InKey:          ch.node.InKey,
 	}
-	err = ch.frameWriter.Initialize()
+	err = ch.frameReadWriter.Initialize()
 	if err != nil {
 		return err
 	}
 
 	ch.streamWriter = &streamwriter.Writer{
-		FrameWriter: ch.frameWriter.Writer,
+		FrameWriter: ch.frameReadWriter.Writer,
 		SystemID:    ch.node.OutSystemID,
 		Version: func() streamwriter.Version {
 			if ch.node.OutVersion == V2 {
@@ -149,14 +200,32 @@ func (ch *Channel) runReader() error {
 	ch.node.pushEvent(&EventChannelOpen{ch})
 
 	for {
-		fr, err := ch.frameWriter.Read()
-		if err != nil {
-			var eerr frame.ReadError
-			if errors.As(err, &eerr) {
+		var fr frame.Frame
+
+		if ch.isDatagram {
+			err := ch.datagramReader.ReadPacket()
+			if err != nil {
+				return err
+			}
+
+			ch.frameReadWriter.ResetBuffer()
+
+			fr, err = ch.frameReadWriter.Read()
+			if err != nil {
 				ch.node.pushEvent(&EventParseError{err, ch})
 				continue
 			}
-			return err
+		} else {
+			var err error
+			fr, err = ch.frameReadWriter.Read()
+			if err != nil {
+				var eerr frame.ReadError
+				if errors.As(err, &eerr) {
+					ch.node.pushEvent(&EventParseError{err, ch})
+					continue
+				}
+				return err
+			}
 		}
 
 		evt := &EventFrame{fr, ch}
@@ -181,7 +250,7 @@ func (ch *Channel) runWriter(writerTerminate chan struct{}) error {
 				}
 
 			case frame.Frame:
-				err := ch.frameWriter.Write(wh)
+				err := ch.frameReadWriter.Write(wh)
 				if err != nil {
 					return err
 				}

--- a/channel_provider.go
+++ b/channel_provider.go
@@ -40,10 +40,11 @@ func (cp *channelProvider) run() {
 		}
 
 		ch := &Channel{
-			node:     cp.node,
-			endpoint: cp.endpoint,
-			label:    label,
-			rwc:      rwc,
+			node:       cp.node,
+			endpoint:   cp.endpoint,
+			label:      label,
+			rwc:        rwc,
+			isDatagram: cp.endpoint.isDatagram(),
 		}
 		err = ch.initialize()
 		if err != nil {

--- a/endpoint.go
+++ b/endpoint.go
@@ -12,5 +12,6 @@ type Endpoint interface {
 	isEndpoint()
 	close()
 	oneChannelAtAtime() bool
+	isDatagram() bool
 	provide() (string, io.ReadWriteCloser, error)
 }

--- a/endpoint_client.go
+++ b/endpoint_client.go
@@ -39,6 +39,10 @@ func (e *endpointClient) oneChannelAtAtime() bool {
 	return true
 }
 
+func (e *endpointClient) isDatagram() bool {
+	return e.conf.IsDatagram
+}
+
 func (e *endpointClient) connect() (io.ReadWriteCloser, error) {
 	timedContext, timedContextClose := context.WithTimeout(e.ctx, e.node.ReadTimeout)
 	nconn, err := e.conf.Connect(timedContext)

--- a/endpoint_custom.go
+++ b/endpoint_custom.go
@@ -64,6 +64,10 @@ func (e *endpointCustom) oneChannelAtAtime() bool {
 	return true
 }
 
+func (e *endpointCustom) isDatagram() bool {
+	return false
+}
+
 func (e *endpointCustom) provide() (string, io.ReadWriteCloser, error) {
 	return "custom", &removeCloser{e.rwc}, nil
 }

--- a/endpoint_custom_client.go
+++ b/endpoint_custom_client.go
@@ -13,6 +13,9 @@ type EndpointCustomClient struct {
 
 	// the label of the protocol
 	Label string
+
+	// whether the connection is datagram-based (e.g. UDP).
+	IsDatagram bool
 }
 
 func (conf EndpointCustomClient) init(node *Node) (Endpoint, error) {

--- a/endpoint_custom_server.go
+++ b/endpoint_custom_server.go
@@ -12,6 +12,9 @@ type EndpointCustomServer struct {
 
 	// the label of the protocol
 	Label string
+
+	// whether the connection is datagram-based (e.g. UDP).
+	IsDatagram bool
 }
 
 func (conf EndpointCustomServer) init(node *Node) (Endpoint, error) {

--- a/endpoint_server.go
+++ b/endpoint_server.go
@@ -44,6 +44,10 @@ func (e *endpointServer) oneChannelAtAtime() bool {
 	return false
 }
 
+func (e *endpointServer) isDatagram() bool {
+	return e.conf.IsDatagram
+}
+
 func (e *endpointServer) provide() (string, io.ReadWriteCloser, error) {
 	nconn, err := e.listener.Accept()
 	if err != nil {

--- a/endpoint_udp_broadcast.go
+++ b/endpoint_udp_broadcast.go
@@ -129,7 +129,8 @@ func (conf EndpointUDPBroadcast) init(node *Node) (Endpoint, error) {
 					broadcastAddr: broadcastAddr,
 				}}, nil
 			},
-			Label: "udp:" + broadcastAddr.String(),
+			Label:      "udp:" + broadcastAddr.String(),
+			IsDatagram: true,
 		},
 	}
 	err = e.initialize()

--- a/endpoint_udp_client.go
+++ b/endpoint_udp_client.go
@@ -18,7 +18,8 @@ func (conf EndpointUDPClient) init(node *Node) (Endpoint, error) {
 			Connect: func(ctx context.Context) (net.Conn, error) {
 				return (&net.Dialer{}).DialContext(ctx, "udp4", conf.Address)
 			},
-			Label: "udp:" + conf.Address,
+			Label:      "udp:" + conf.Address,
+			IsDatagram: true,
 		},
 	}
 	err := e.initialize()

--- a/endpoint_udp_client_test.go
+++ b/endpoint_udp_client_test.go
@@ -1,0 +1,130 @@
+package gomavlib
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bluenviron/gomavlib/v3/pkg/dialect"
+	"github.com/bluenviron/gomavlib/v3/pkg/frame"
+	"github.com/bluenviron/gomavlib/v3/pkg/streamwriter"
+)
+
+func TestEndpointUDPClientDatagramRecovery(t *testing.T) {
+	pc, err := net.ListenPacket("udp4", "127.0.0.1:5604")
+	require.NoError(t, err)
+	defer pc.Close()
+
+	serverDone := make(chan struct{})
+
+	go func() {
+		defer close(serverDone)
+
+		buf := make([]byte, 4096)
+		_, clientAddr, err2 := pc.ReadFrom(buf)
+		require.NoError(t, err2)
+
+		// first malformed packet (too short)
+		_, err2 = pc.WriteTo([]byte{frame.V2MagicByte}, clientAddr)
+		require.NoError(t, err2)
+
+		// second malformed packet (unknown incompatibility flag, with trailing payload+checksum bytes
+		_, err2 = pc.WriteTo([]byte{frame.V2MagicByte, 5, 0x04, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, clientAddr)
+		require.NoError(t, err2)
+
+		// valid packet
+		dialectRW := &dialect.ReadWriter{Dialect: testDialect}
+		err2 = dialectRW.Initialize()
+		require.NoError(t, err2)
+
+		var frameBuf bytes.Buffer
+		rw := &frame.ReadWriter{
+			ByteReadWriter: &frameBuf,
+			DialectRW:      dialectRW,
+		}
+		err2 = rw.Initialize()
+		require.NoError(t, err2)
+
+		sw := &streamwriter.Writer{
+			FrameWriter: rw.Writer,
+			Version:     streamwriter.V2,
+			SystemID:    11,
+		}
+		err2 = sw.Initialize()
+		require.NoError(t, err2)
+
+		err2 = sw.Write(&MessageHeartbeat{
+			Type:           6,
+			Autopilot:      5,
+			BaseMode:       4,
+			CustomMode:     3,
+			SystemStatus:   2,
+			MavlinkVersion: 1,
+		})
+		require.NoError(t, err2)
+
+		_, err2 = pc.WriteTo(frameBuf.Bytes(), clientAddr)
+		require.NoError(t, err2)
+	}()
+
+	node := &Node{
+		Dialect:          testDialect,
+		OutVersion:       V2,
+		OutSystemID:      10,
+		Endpoints:        []EndpointConf{EndpointUDPClient{"127.0.0.1:5604"}},
+		HeartbeatDisable: true,
+	}
+	err = node.Initialize()
+	require.NoError(t, err)
+	defer node.Close()
+
+	evt := <-node.Events()
+	require.Equal(t, &EventChannelOpen{
+		Channel: evt.(*EventChannelOpen).Channel,
+	}, evt)
+
+	err = node.WriteMessageAll(&MessageHeartbeat{
+		Type:           1,
+		Autopilot:      2,
+		BaseMode:       3,
+		CustomMode:     6,
+		SystemStatus:   4,
+		MavlinkVersion: 5,
+	})
+	require.NoError(t, err)
+
+	evt = <-node.Events()
+	parseErr, ok := evt.(*EventParseError)
+	require.True(t, ok)
+	require.EqualError(t, parseErr.Error, "packet is too short")
+
+	evt = <-node.Events()
+	parseErr, ok = evt.(*EventParseError)
+	require.True(t, ok)
+	require.EqualError(t, parseErr.Error, "unknown incompatibility flag: 4")
+
+	evt = <-node.Events()
+	fr, ok := evt.(*EventFrame)
+	require.True(t, ok)
+	require.Equal(t, &EventFrame{
+		Frame: &frame.V2Frame{
+			SequenceNumber: 0,
+			SystemID:       11,
+			ComponentID:    1,
+			Message: &MessageHeartbeat{
+				Type:           6,
+				Autopilot:      5,
+				BaseMode:       4,
+				CustomMode:     3,
+				SystemStatus:   2,
+				MavlinkVersion: 1,
+			},
+			Checksum: fr.Frame.GetChecksum(),
+		},
+		Channel: fr.Channel,
+	}, evt)
+
+	<-serverDone
+}

--- a/endpoint_udp_server.go
+++ b/endpoint_udp_server.go
@@ -26,7 +26,8 @@ func (conf EndpointUDPServer) init(node *Node) (Endpoint, error) {
 
 				return udp.Listen("udp4", addr)
 			},
-			Label: "udp",
+			Label:      "udp",
+			IsDatagram: true,
 		},
 	}
 	err := e.initialize()

--- a/pkg/frame/reader.go
+++ b/pkg/frame/reader.go
@@ -214,3 +214,8 @@ func (r *Reader) Read() (Frame, error) {
 
 	return f, nil
 }
+
+// ResetBuffer discards data in the read buffer.
+func (r *Reader) ResetBuffer() {
+	r.BufByteReader.Discard(r.BufByteReader.Buffered()) //nolint:errcheck
+}


### PR DESCRIPTION
Replaces #246 

When the endpoint is datagram-based and there's an error, discard buffered data and skip directly to the next datagram.